### PR TITLE
Backend service i controller dla cp red stats

### DIFF
--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -257,6 +257,42 @@
                 <option name="folders">
                   <list>
                     <folderState>
+                      <option name="folders">
+                        <list>
+                          <folderState>
+                            <option name="folders">
+                              <list>
+                                <folderState>
+                                  <option name="id" value="47ddc209-abfd-4d50-b623-d488bf806a5a" />
+                                  <option name="name" value="Stats" />
+                                  <option name="requests">
+                                    <list>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  name: &quot;Inteligencja&quot;,&#10;  tag: &quot;INT&quot;,&#10;  description: &quot;Określa ogólną sprawność rozumowania. Według zasad to nie tylko czysta inteligencja, lecz także spryt, wiedza, spostrzegawczość i zdolność uczenia się&quot;,&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Dodaje statystyke" />
+                                        <option name="id" value="9f77ae3c-30a3-4b5d-83ab-0020324556c9" />
+                                        <option name="method" value="POST" />
+                                        <option name="name" value="Dodaj statystyke" />
+                                        <option name="sortWeight" value="1000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/stats/add" />
+                                      </requestState>
+                                    </list>
+                                  </option>
+                                  <option name="sortWeight" value="1000000" />
+                                </folderState>
+                              </list>
+                            </option>
+                            <option name="id" value="22a51bac-54eb-48dd-a9c8-e0df68e57dae" />
+                            <option name="name" value="Manual" />
+                            <option name="sortWeight" value="1000000" />
+                          </folderState>
+                        </list>
+                      </option>
                       <option name="id" value="be9e305b-7eae-442e-9183-34c14c9991a5" />
                       <option name="name" value="CpRed" />
                       <option name="requests">

--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -270,7 +270,7 @@
                                       <requestState>
                                         <option name="body">
                                           <bodyState>
-                                            <option name="raw" value="{&#10;  name: &quot;Inteligencja&quot;,&#10;  tag: &quot;INT&quot;,&#10;  description: &quot;Określa ogólną sprawność rozumowania. Według zasad to nie tylko czysta inteligencja, lecz także spryt, wiedza, spostrzegawczość i zdolność uczenia się&quot;,&#10;}" />
+                                            <option name="raw" value="{&#10;  name: &quot;Inteligencja 3&quot;,&#10;  tag: &quot;INT 3&quot;,&#10;  changeable: true,&#10;  description: &quot;Określa ogólną sprawność rozumowania. Według zasad to nie tylko czysta inteligencja, lecz także spryt, wiedza, spostrzegawczość i zdolność uczenia się&quot;&#10;}" />
                                             <option name="type" value="JSON" />
                                           </bodyState>
                                         </option>
@@ -284,7 +284,7 @@
                                       <requestState>
                                         <option name="body">
                                           <bodyState>
-                                            <option name="raw" value="{&#10;  name: &quot;Inteligencja zmodyfikowana&quot;,&#10;  description: &quot;Inny opis&quot;,&#10;}" />
+                                            <option name="raw" value="{&#10;  name: &quot;Inteligencja zmodyfikowana 4&quot;,&#10;  description: &quot;Inny opis&quot;,&#10;}" />
                                             <option name="type" value="JSON" />
                                           </bodyState>
                                         </option>
@@ -293,7 +293,7 @@
                                         <option name="method" value="PUT" />
                                         <option name="name" value="Modyfikuj statystyke" />
                                         <option name="sortWeight" value="2000000" />
-                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/stats/update/1" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/stats/update/2" />
                                       </requestState>
                                       <requestState>
                                         <option name="description" value="Pobiera listę statystyk" />

--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -284,7 +284,7 @@
                                       <requestState>
                                         <option name="body">
                                           <bodyState>
-                                            <option name="raw" value="{&#10;  name: &quot;Inteligencja zmodyfikowana 4&quot;,&#10;  description: &quot;Inny opis&quot;,&#10;}" />
+                                            <option name="raw" value="{&#10;  description: &quot;Inny opis&quot;&#10;}&#10;" />
                                             <option name="type" value="JSON" />
                                           </bodyState>
                                         </option>
@@ -293,7 +293,15 @@
                                         <option name="method" value="PUT" />
                                         <option name="name" value="Modyfikuj statystyke" />
                                         <option name="sortWeight" value="2000000" />
-                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/stats/update/2" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/stats/update/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zmienia wartość isChengable " />
+                                        <option name="id" value="596a9d5a-0cfb-4e36-aa56-c8a517ca3727" />
+                                        <option name="method" value="PUT" />
+                                        <option name="name" value="Zmień zmienność" />
+                                        <option name="sortWeight" value="2500000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/stats/changeable/1" />
                                       </requestState>
                                       <requestState>
                                         <option name="description" value="Pobiera listę statystyk" />

--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -281,6 +281,44 @@
                                         <option name="sortWeight" value="1000000" />
                                         <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/stats/add" />
                                       </requestState>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  name: &quot;Inteligencja zmodyfikowana&quot;,&#10;  description: &quot;Inny opis&quot;,&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Modyfikuje statystyke o podanym id" />
+                                        <option name="id" value="ed78e2d1-c80c-4ffa-ad0c-795f66670a8a" />
+                                        <option name="method" value="PUT" />
+                                        <option name="name" value="Modyfikuj statystyke" />
+                                        <option name="sortWeight" value="2000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/stats/update/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Pobiera listę statystyk" />
+                                        <option name="id" value="16cfbf22-7be1-4d81-a712-b90f11d0d967" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobierz wszystkie statystyki" />
+                                        <option name="sortWeight" value="3000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/stats/all" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca konkretną statystykę o podanym id" />
+                                        <option name="id" value="da681b4c-840d-4092-8ab1-a5b302ddcbd9" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobierz statystykę po id" />
+                                        <option name="sortWeight" value="4000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/stats/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Pobiera listę wszystkich statystyk w wersji dla admina" />
+                                        <option name="id" value="83906745-40b9-4567-b146-c178d5d853d4" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobierz wszstkie statystyki dla Admina" />
+                                        <option name="sortWeight" value="5000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/stats/all" />
+                                      </requestState>
                                     </list>
                                   </option>
                                   <option name="sortWeight" value="1000000" />

--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -284,7 +284,7 @@
                                       <requestState>
                                         <option name="body">
                                           <bodyState>
-                                            <option name="raw" value="{&#10;  description: &quot;Inny opis&quot;&#10;}&#10;" />
+                                            <option name="raw" value="{&#10;  tag: &quot;INT&quot;,&#10;  description: &quot;Inny opis&quot;&#10;}&#10;" />
                                             <option name="type" value="JSON" />
                                           </bodyState>
                                         </option>
@@ -323,7 +323,7 @@
                                         <option name="description" value="Pobiera listę wszystkich statystyk w wersji dla admina" />
                                         <option name="id" value="83906745-40b9-4567-b146-c178d5d853d4" />
                                         <option name="method" value="GET" />
-                                        <option name="name" value="Pobierz wszstkie statystyki dla Admina" />
+                                        <option name="name" value="Pobierz wszystkie statystyki dla Admina" />
                                         <option name="sortWeight" value="5000000" />
                                         <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/stats/all" />
                                       </requestState>

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStats.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStats.java
@@ -23,8 +23,10 @@ public class CpRedStats {
     private Long id;
     private String name;
     private String tag;
+
     private boolean changeable;
 
     @Column(length = 500)
     private String description;
+
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStats.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStats.java
@@ -22,6 +22,9 @@ public class CpRedStats {
     )
     private Long id;
     private String name;
+    private String tag;
     private boolean changeable;
+
+    @Column(length = 500)
     private String description;
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsController.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsController.java
@@ -12,33 +12,33 @@ import java.util.Map;
 public class CpRedStatsController {
     private final CpRedStatsService cpRedStatsService;
 
-//    // ============ User methods ============
-//    // Pobierz wszystkie statystyki
-//    @GetMapping(path = "/rpgSystems/cpRed/stats/all")
-//    public List<CpRedStatsDTO> getAllStats() {
-//        return cpRedStatsService.getAllStats();
-//    }
-//    // Pobierz statystykę po id
-//    @GetMapping(path = "/rpgSystems/cpRed/stats/{statId}")
-//    public CpRedStatsDTO getStatById(@PathVariable("statId") Long statId) {
-//        return cpRedStatsService.getStatById(statId);
-//    }
-//
-//    // ============ Admin methods ============
-//    // Pobierz wszystkie statystyki dla admina
-//    @GetMapping(path = "/admin/rpgSystems/cpRed/stats/all")
-//    public List<CpRedStats> getAllStatsForAdmin() {
-//        return cpRedStatsService.getAllStatsForAdmin();
-//    }
-//    // Dodać statystykę
-//    @GetMapping(path = "/admin/rpgSystems/cpRed/stats/add")
-//    public Map<String, Object> addStat(CpRedStats cpRedStats) {
-//        return cpRedStatsService.addStat(cpRedStats);
-//    }
-//    // Modyfikować statystykę
-//    @GetMapping(path = "/admin/rpgSystems/cpRed/stats/update/{statId}")
-//    public Map<String, Object> updateStat(@PathVariable("statId") Long statId,
-//                                          @RequestBody CpRedStats cpRedStats) {
-//        return cpRedStatsService.updateStat(statId, cpRedStats);
-//    }
+    // ============ User methods ============
+    // Pobierz wszystkie statystyki
+    @GetMapping(path = "/rpgSystems/cpRed/stats/all")
+    public List<CpRedStatsDTO> getAllStats() {
+        return cpRedStatsService.getAllStats();
+    }
+    // Pobierz statystykę po id
+    @GetMapping(path = "/rpgSystems/cpRed/stats/{statId}")
+    public CpRedStatsDTO getStatById(@PathVariable("statId") Long statId) {
+        return cpRedStatsService.getStatById(statId);
+    }
+
+    // ============ Admin methods ============
+    // Pobierz wszystkie statystyki dla admina
+    @GetMapping(path = "/admin/rpgSystems/cpRed/stats/all")
+    public List<CpRedStats> getAllStatsForAdmin() {
+        return cpRedStatsService.getAllStatsForAdmin();
+    }
+    // Dodać statystykę
+    @GetMapping(path = "/admin/rpgSystems/cpRed/stats/add")
+    public Map<String, Object> addStat(CpRedStats cpRedStats) {
+        return cpRedStatsService.addStat(cpRedStats);
+    }
+    // Modyfikować statystykę
+    @GetMapping(path = "/admin/rpgSystems/cpRed/stats/update/{statId}")
+    public Map<String, Object> updateStat(@PathVariable("statId") Long statId,
+                                          @RequestBody CpRedStats cpRedStats) {
+        return cpRedStatsService.updateStat(statId, cpRedStats);
+    }
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsController.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsController.java
@@ -33,7 +33,7 @@ public class CpRedStatsController {
     }
     // Dodać statystykę
     @PostMapping(path = "/admin/rpgSystems/cpRed/stats/add")
-    public Map<String, Object> addStat(CpRedStats cpRedStats) {
+    public Map<String, Object> addStat(@RequestBody CpRedStats cpRedStats) {
         return cpRedStatsService.addStat(cpRedStats);
     }
     // Modyfikować statystykę

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsController.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsController.java
@@ -42,4 +42,9 @@ public class CpRedStatsController {
                                           @RequestBody CpRedStats cpRedStats) {
         return cpRedStatsService.updateStat(statId, cpRedStats);
     }
+    // Zmienić zmienność statystyki
+    @PutMapping(path = "/admin/rpgSystems/cpRed/stats/changeable/{statId}")
+    public Map<String, Object> changeStatChangeable(@PathVariable("statId") Long statId) {
+        return cpRedStatsService.changeStatChangeable(statId);
+    }
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsController.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsController.java
@@ -24,6 +24,7 @@ public class CpRedStatsController {
         return cpRedStatsService.getStatById(statId);
     }
 
+
     // ============ Admin methods ============
     // Pobierz wszystkie statystyki dla admina
     @GetMapping(path = "/admin/rpgSystems/cpRed/stats/all")
@@ -31,12 +32,12 @@ public class CpRedStatsController {
         return cpRedStatsService.getAllStatsForAdmin();
     }
     // Dodać statystykę
-    @GetMapping(path = "/admin/rpgSystems/cpRed/stats/add")
+    @PostMapping(path = "/admin/rpgSystems/cpRed/stats/add")
     public Map<String, Object> addStat(CpRedStats cpRedStats) {
         return cpRedStatsService.addStat(cpRedStats);
     }
     // Modyfikować statystykę
-    @GetMapping(path = "/admin/rpgSystems/cpRed/stats/update/{statId}")
+    @PutMapping(path = "/admin/rpgSystems/cpRed/stats/update/{statId}")
     public Map<String, Object> updateStat(@PathVariable("statId") Long statId,
                                           @RequestBody CpRedStats cpRedStats) {
         return cpRedStatsService.updateStat(statId, cpRedStats);

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsDTO.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsDTO.java
@@ -9,5 +9,6 @@ import lombok.ToString;
 @ToString
 public class CpRedStatsDTO {
     private String name;
+    private String tag;
     private String description;
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsRepository.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 public interface CpRedStatsRepository extends JpaRepository<CpRedStats, Long> {
 
     boolean existsByName(String name);
+    boolean existsByTag(String tag);
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsRepository.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CpRedStatsRepository extends JpaRepository<CpRedStats, Long> {
 
-
+    boolean existsByName(String name);
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsService.java
@@ -4,6 +4,7 @@ import dev.goral.rpgmanager.security.CustomReturnables;
 import dev.goral.rpgmanager.security.exceptions.ResourceNotFoundException;
 import dev.goral.rpgmanager.user.User;
 import dev.goral.rpgmanager.user.UserRepository;
+import dev.goral.rpgmanager.user.UserRole;
 import lombok.AllArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -53,7 +54,7 @@ public class CpRedStatsService {
                 .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
 
         // Sprawdź, czy użytkownik ma rolę ADMIN
-        if (!currentUser.getRole().equals("ROLE_ADMIN")) {
+        if (!currentUser.getRole().equals(UserRole.ROLE_ADMIN)) {
             throw new IllegalStateException("Nie masz uprawnień do dodawania statystyk.");
         }
 
@@ -62,31 +63,39 @@ public class CpRedStatsService {
             throw new IllegalStateException("Statystyka o tej samej nazwie już istnieje.");
         }
 
-        // Sprawdź długość nazwy
-        if (cpRedStats.getName().length() > 255) {
-            throw new IllegalStateException("Nazwa statystyki jest za długa. Maksymalna długość to 255 znaków.");
+        if(cpRedStats.getName() == null || cpRedStats.getTag() == null || cpRedStats.getDescription() == null) {
+            throw new IllegalStateException("Nie wszystkie pola zostały wypełnione.");
         }
+
         // Sprawdzenie, czy nazwa nie jest pusta lub skłąda się tylko z białych znaków
         if (cpRedStats.getName().isEmpty() || cpRedStats.getName().trim().isEmpty()) {
             throw new IllegalStateException("Nazwa statystyki nie może być pusta.");
         }
+        // Sprawdź długość nazwy
+        if (cpRedStats.getName().length() > 255) {
+            throw new IllegalStateException("Nazwa statystyki jest za długa. Maksymalna długość to 255 znaków.");
+        }
 
-        // Strawdzenie długości tagu
-        if (cpRedStats.getTag().length() > 255) {
-            throw new IllegalStateException("Tag statystyki jest za długi. Maksymalna długość to 255 znaków.");
+        // Sprawdzenie, czy taki tag już istnieje
+        if (cpRedStatsRepository.existsByTag(cpRedStats.getTag())) {
+            throw new IllegalStateException("Statystyka o tym tagu już istnieje.");
         }
         // Sprawdzenie, czy tag nie jest pusty lub skłąda się tylko z białych znaków
         if (cpRedStats.getTag().isEmpty() || cpRedStats.getTag().trim().isEmpty()) {
             throw new IllegalStateException("Tag statystyki nie może być pusty.");
         }
-
-        // Sprawdź długość opisu
-        if (cpRedStats.getDescription().length() > 500) {
-            throw new IllegalStateException("Opis statystyki jest za długi. Maksymalna długość to 500 znaków.");
+        // Strawdzenie długości tagu
+        if (cpRedStats.getTag().length() > 255) {
+            throw new IllegalStateException("Tag statystyki jest za długi. Maksymalna długość to 255 znaków.");
         }
+
         // Sprawdzenie, czy opis nie jest pusty lub skłąda się tylko z białych znaków
         if (cpRedStats.getDescription().isEmpty() || cpRedStats.getDescription().trim().isEmpty()) {
             throw new IllegalStateException("Opis statystyki nie może być pusty.");
+        }
+        // Sprawdź długość opisu
+        if (cpRedStats.getDescription().length() > 500) {
+            throw new IllegalStateException("Opis statystyki jest za długi. Maksymalna długość to 500 znaków.");
         }
 
         // Zaspisanie statystyki do bazy danych
@@ -105,7 +114,7 @@ public class CpRedStatsService {
                 .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
 
         // Sprawdź, czy użytkownik ma rolę ADMIN
-        if (!currentUser.getRole().equals("ROLE_ADMIN")) {
+        if (!currentUser.getRole().equals(UserRole.ROLE_ADMIN)) {
             throw new IllegalStateException("Nie masz uprawnień do dodawania statystyk.");
         }
 
@@ -129,6 +138,10 @@ public class CpRedStatsService {
 
         // Sprawdzenie tagu
         if (cpRedStats.getTag() != null) {
+            // Sprawdzenie, czy taki tag już istnieje
+            if (cpRedStatsRepository.existsByTag(cpRedStats.getTag())) {
+                throw new IllegalStateException("Statystyka o tym tagu już istnieje.");
+            }
             // Sprawdź długość tagu
             if (cpRedStats.getTag().length() > 255) {
                 throw new IllegalStateException("Tag statystyki jest za długi. Maksymalna długość to 255 znaków.");

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsService.java
@@ -115,7 +115,7 @@ public class CpRedStatsService {
 
         // Sprawdź, czy użytkownik ma rolę ADMIN
         if (!currentUser.getRole().equals(UserRole.ROLE_ADMIN)) {
-            throw new IllegalStateException("Nie masz uprawnień do dodawania statystyk.");
+            throw new IllegalStateException("Nie masz uprawnień do modyfikacji statystyk.");
         }
 
         // Sprawdzenie nazwy
@@ -166,12 +166,27 @@ public class CpRedStatsService {
             statToUpdate.setDescription(cpRedStats.getDescription());
         }
 
-        // Sprawdzenie zmienności
-        if (cpRedStats.isChangeable() != statToUpdate.isChangeable()) {
-            statToUpdate.setChangeable(cpRedStats.isChangeable());
-        }
-
         cpRedStatsRepository.save(statToUpdate);
         return CustomReturnables.getOkResponseMap("Statystyka została zaktualizowana.");
+    }
+
+    // Zmienić zmienność statystyki
+    public Map<String, Object> changeStatChangeable(Long id) {
+        CpRedStats statToUpdate = cpRedStatsRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Statystyka o id " + id + " nie istnieje"));
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
+
+        // Sprawdź, czy użytkownik ma rolę ADMIN
+        if (!currentUser.getRole().equals(UserRole.ROLE_ADMIN)) {
+            throw new IllegalStateException("Nie masz uprawnień do modyfikacji statystyk.");
+        }
+
+        statToUpdate.setChangeable(!statToUpdate.isChangeable());
+        cpRedStatsRepository.save(statToUpdate);
+        return CustomReturnables.getOkResponseMap("Zmienność statystyki została zmieniona.");
     }
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/stats/CpRedStatsService.java
@@ -1,38 +1,164 @@
 package dev.goral.rpgmanager.rpgSystems.cpRed.manual.stats;
 
+import dev.goral.rpgmanager.security.CustomReturnables;
+import dev.goral.rpgmanager.security.exceptions.ResourceNotFoundException;
+import dev.goral.rpgmanager.user.User;
+import dev.goral.rpgmanager.user.UserRepository;
 import lombok.AllArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
 public class CpRedStatsService {
     private final CpRedStatsRepository cpRedStatsRepository;
+    private final UserRepository userRepository;
 
-//    // Pobierz wszystkie statystyki
-//    public List<CpRedStatsDTO> getAllStats() {
-//
-//    }
-//
-//    // Pobierz statystyke po id
-//    public CpRedStatsDTO getStatById(Long id) {
-//
-//    }
-//
-//    // Pobierz wszystkie statystyki dla admina
-//    public List<CpRedStats> getAllStatsForAdmin() {
-//        return cpRedStatsRepository.findAll();
-//    }
-//
-//    // Dodać statystyke
-//    public Map<String, Object> addStat(CpRedStats cpRedStats) {
-//
-//    }
-//
-//    // Modyfikować statystyke
-//    public Map<String, Object> updateStat(Long id, CpRedStats cpRedStats) {
-//
-//    }
+    // Pobierz wszystkie statystyki
+    public List<CpRedStatsDTO> getAllStats() {
+        List<CpRedStats> cpRedStatsList = cpRedStatsRepository.findAll();
+        return cpRedStatsList.stream()
+                .map(cpRedStats -> new CpRedStatsDTO(
+                        cpRedStats.getName(),
+                        cpRedStats.getTag(),
+                        cpRedStats.getDescription()
+                )).collect(Collectors.toList());
+    }
+
+    // Pobierz statystyke po id
+    public CpRedStatsDTO getStatById(Long id) {
+        return cpRedStatsRepository.findById(id)
+                .map(cpRedStats -> new CpRedStatsDTO(
+                        cpRedStats.getName(),
+                        cpRedStats.getTag(),
+                        cpRedStats.getDescription()
+                )).orElseThrow(() -> new ResourceNotFoundException("Statystyka o id " + id + " nie istnieje"));
+    }
+
+    // Pobierz wszystkie statystyki dla admina
+    public List<CpRedStats> getAllStatsForAdmin() {
+        return cpRedStatsRepository.findAll();
+    }
+
+    // Dodać statystyke
+    public Map<String, Object> addStat(CpRedStats cpRedStats) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
+
+        // Sprawdź, czy użytkownik ma rolę ADMIN
+        if (!currentUser.getRole().equals("ROLE_ADMIN")) {
+            throw new IllegalStateException("Nie masz uprawnień do dodawania statystyk.");
+        }
+
+        // Sprawdź, czy statystyka o tej samej nazwie już istnieje
+        if (cpRedStatsRepository.existsByName(cpRedStats.getName())) {
+            throw new IllegalStateException("Statystyka o tej samej nazwie już istnieje.");
+        }
+
+        // Sprawdź długość nazwy
+        if (cpRedStats.getName().length() > 255) {
+            throw new IllegalStateException("Nazwa statystyki jest za długa. Maksymalna długość to 255 znaków.");
+        }
+        // Sprawdzenie, czy nazwa nie jest pusta lub skłąda się tylko z białych znaków
+        if (cpRedStats.getName().isEmpty() || cpRedStats.getName().trim().isEmpty()) {
+            throw new IllegalStateException("Nazwa statystyki nie może być pusta.");
+        }
+
+        // Strawdzenie długości tagu
+        if (cpRedStats.getTag().length() > 255) {
+            throw new IllegalStateException("Tag statystyki jest za długi. Maksymalna długość to 255 znaków.");
+        }
+        // Sprawdzenie, czy tag nie jest pusty lub skłąda się tylko z białych znaków
+        if (cpRedStats.getTag().isEmpty() || cpRedStats.getTag().trim().isEmpty()) {
+            throw new IllegalStateException("Tag statystyki nie może być pusty.");
+        }
+
+        // Sprawdź długość opisu
+        if (cpRedStats.getDescription().length() > 500) {
+            throw new IllegalStateException("Opis statystyki jest za długi. Maksymalna długość to 500 znaków.");
+        }
+        // Sprawdzenie, czy opis nie jest pusty lub skłąda się tylko z białych znaków
+        if (cpRedStats.getDescription().isEmpty() || cpRedStats.getDescription().trim().isEmpty()) {
+            throw new IllegalStateException("Opis statystyki nie może być pusty.");
+        }
+
+        // Zaspisanie statystyki do bazy danych
+        cpRedStatsRepository.save(cpRedStats);
+        return CustomReturnables.getOkResponseMap("Statystyka została dodana.");
+    }
+
+    // Modyfikować statystyke
+    public Map<String, Object> updateStat(Long id, CpRedStats cpRedStats) {
+        CpRedStats statToUpdate = cpRedStatsRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Statystyka o id " + id + " nie istnieje"));
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
+
+        // Sprawdź, czy użytkownik ma rolę ADMIN
+        if (!currentUser.getRole().equals("ROLE_ADMIN")) {
+            throw new IllegalStateException("Nie masz uprawnień do dodawania statystyk.");
+        }
+
+        // Sprawdzenie nazwy
+        if (cpRedStats.getName() != null) {
+            // Sprawdź, czy statystyka o tej samej nazwie już istnieje
+            if (cpRedStatsRepository.existsByName(cpRedStats.getName())) {
+                throw new IllegalStateException("Statystyka o tej samej nazwie już istnieje.");
+            }
+            // Sprawdź długość nazwy
+            if (cpRedStats.getName().length() > 255) {
+                throw new IllegalStateException("Nazwa statystyki jest za długa. Maksymalna długość to 255 znaków.");
+            }
+            // Sprawdzenie, czy nazwa nie jest pusta lub skłąda się tylko z białych znaków
+            if (cpRedStats.getName().isEmpty() || cpRedStats.getName().trim().isEmpty()) {
+                throw new IllegalStateException("Nazwa statystyki nie może być pusta.");
+            }
+
+            statToUpdate.setName(cpRedStats.getName());
+        }
+
+        // Sprawdzenie tagu
+        if (cpRedStats.getTag() != null) {
+            // Sprawdź długość tagu
+            if (cpRedStats.getTag().length() > 255) {
+                throw new IllegalStateException("Tag statystyki jest za długi. Maksymalna długość to 255 znaków.");
+            }
+            // Sprawdzenie, czy tag nie jest pusty lub skłąda się tylko z białych znaków
+            if (cpRedStats.getTag().isEmpty() || cpRedStats.getTag().trim().isEmpty()) {
+                throw new IllegalStateException("Tag statystyki nie może być pusty.");
+            }
+            statToUpdate.setTag(cpRedStats.getTag());
+        }
+
+        // Sprawdzenie opisu
+        if (cpRedStats.getDescription() != null) {
+            // Sprawdź długość opisu
+            if (cpRedStats.getDescription().length() > 500) {
+                throw new IllegalStateException("Opis statystyki jest za długi. Maksymalna długość to 500 znaków.");
+            }
+            // Sprawdzenie, czy opis nie jest pusty lub skłąda się tylko z białych znaków
+            if (cpRedStats.getDescription().isEmpty() || cpRedStats.getDescription().trim().isEmpty()) {
+                throw new IllegalStateException("Opis statystyki nie może być pusty.");
+            }
+            statToUpdate.setDescription(cpRedStats.getDescription());
+        }
+
+        // Sprawdzenie zmienności
+        if (cpRedStats.isChangeable() != statToUpdate.isChangeable()) {
+            statToUpdate.setChangeable(cpRedStats.isChangeable());
+        }
+
+        cpRedStatsRepository.save(statToUpdate);
+        return CustomReturnables.getOkResponseMap("Statystyka została zaktualizowana.");
+    }
 }


### PR DESCRIPTION
### Info dla testerów
Do przetestowania 5 endpointów w encji `CpRedStats`. 
Porobiłem w JetCliencie zapytania. Ta encja blokuje mi prace nad innymi więc prosiłbym o względny pośpiech zwłaszcza że dużo nie ma.
Tworzenie i modyfikowanie statystyki powinno być tylko dla admina, zwykły user powinien móc tylko wyświetlać.
A i polecam robić od razu dokumentacje na bieżąco jak będzie działać ;)