### PR TITLE
Meeting Scheduler

### DIFF
--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -523,6 +523,20 @@
                             <option name="sortWeight" value="2000000" />
                             <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/availability/{schedulerId}" />
                           </requestState>
+                          <requestState>
+                            <option name="body">
+                              <bodyState>
+                                <option name="raw" value="{&#10;  &quot;schedulerId&quot;: 1,&#10;  &quot;slots&quot;: [&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2023-12-20T17:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2023-12-20T21:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;YES&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2023-12-22T19:30:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2023-12-22T23:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;YES&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2023-12-25T15:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2023-12-25T19:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;MAYBE&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2023-12-29T18:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2023-12-29T22:30:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;NO&quot;&#10;    }&#10;  ]&#10;}" />
+                                <option name="type" value="JSON" />
+                              </bodyState>
+                            </option>
+                            <option name="description" value="Edytuj dyspozycję" />
+                            <option name="id" value="26a3bdf4-a5a0-4d9a-8ae4-a8e3753d71ca" />
+                            <option name="method" value="PUT" />
+                            <option name="name" value="Edit Availability" />
+                            <option name="sortWeight" value="3000000" />
+                            <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/editAvailability" />
+                          </requestState>
                         </list>
                       </option>
                       <option name="sortWeight" value="1000000" />

--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -566,24 +566,23 @@
                       <option name="id" value="9d7e0c51-6c4a-4f34-9c2f-1999b00c1114" />
                       <option name="method" value="GET" />
                       <option name="name" value="Get Scheduler" />
+                      <option name="pathVariables">
+                        <list>
+                          <pathVariableState>
+                            <option name="key" value="schedulerId" />
+                          </pathVariableState>
+                        </list>
+                      </option>
                       <option name="sortWeight" value="1000000" />
-                      <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/forGame/1" />
+                      <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/{schedulerId}" />
                     </requestState>
                     <requestState>
                       <option name="description" value="Pobierz schedulery dla konkretnej gry" />
                       <option name="id" value="73d75294-bb3b-42df-990b-cfbbf77782de" />
                       <option name="method" value="GET" />
                       <option name="name" value="Get Scheduler for Game" />
-                      <option name="pathVariables">
-                        <list>
-                          <pathVariableState>
-                            <option name="key" value="schedulerId" />
-                            <option name="value" value="2" />
-                          </pathVariableState>
-                        </list>
-                      </option>
                       <option name="sortWeight" value="1500000" />
-                      <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/{schedulerId}" />
+                      <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/forGame/1" />
                     </requestState>
                     <requestState>
                       <option name="body">

--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -652,6 +652,22 @@
                       <option name="sortWeight" value="7000000" />
                       <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/sendFinalDecisionMails/{schedulerId}" />
                     </requestState>
+                    <requestState>
+                      <option name="description" value="Pobierz dyspozycję od każdego z użytkowników" />
+                      <option name="id" value="1bec69e7-7bf4-47ff-a426-8ac24829a8e5" />
+                      <option name="method" value="GET" />
+                      <option name="name" value="Get All Players Availability" />
+                      <option name="pathVariables">
+                        <list>
+                          <pathVariableState>
+                            <option name="key" value="schedulerId" />
+                            <option name="value" value="1" />
+                          </pathVariableState>
+                        </list>
+                      </option>
+                      <option name="sortWeight" value="8000000" />
+                      <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/availability/{schedulerId}/all" />
+                    </requestState>
                   </list>
                 </option>
                 <option name="sortWeight" value="6000000" />

--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -166,7 +166,7 @@
                     <requestState>
                       <option name="body">
                         <bodyState>
-                          <option name="raw" value="{&#10;  &quot;name&quot;: &quot;Example Game&quot;,&#10;  &quot;description&quot;: &quot;This is an example game description.&quot;,&#10;  &quot;rpgSystem&quot;: {&#10;    &quot;id&quot;: 1&#10;  }&#10;}" />
+                          <option name="raw" value="{&#10;  &quot;name&quot;: &quot;Example Game 2&quot;,&#10;  &quot;description&quot;: &quot;This is an example game description. 2&quot;,&#10;  &quot;rpgSystem&quot;: {&#10;    &quot;id&quot;: 1&#10;  }&#10;}" />
                           <option name="type" value="JSON" />
                         </bodyState>
                       </option>
@@ -378,7 +378,7 @@
                     <requestState>
                       <option name="body">
                         <bodyState>
-                          <option name="raw" value="{&#10;  &quot;gameId&quot;: 1,&#10;  &quot;userId&quot;: 3,&#10;  &quot;title&quot;: &quot;Test 3&quot;,&#10;  &quot;content&quot;: &quot;# **Test**&quot;&#10;}" />
+                          <option name="raw" value="{&#10;  &quot;gameId&quot;: 1,&#10;  &quot;userId&quot;: 1,&#10;  &quot;title&quot;: &quot;Test 3&quot;,&#10;  &quot;content&quot;: &quot;# **Test**&quot;&#10;}" />
                           <option name="type" value="JSON" />
                         </bodyState>
                       </option>
@@ -405,7 +405,7 @@
                     <requestState>
                       <option name="body">
                         <bodyState>
-                          <option name="raw" value="{&#10;  &quot;gameId&quot;: 1,&#10;  &quot;userId&quot;: 1,&#10;  &quot;title&quot;: &quot;Pierwsza notatka - edytowana&quot;,&#10;  &quot;content&quot;: &quot;Zmieniona treść notatki *markdown* po edycji.&quot;&#10;}" />
+                          <option name="raw" value="{&#10;  &quot;gameId&quot;: 2,&#10;  &quot;userId&quot;: 1,&#10;  &quot;title&quot;: &quot;Pierwsza notatka - edytowana&quot;,&#10;  &quot;content&quot;: &quot;Zmieniona treść notatki *markdown* po edycji.&quot;&#10;}" />
                           <option name="type" value="JSON" />
                         </bodyState>
                       </option>
@@ -483,6 +483,165 @@
                   </list>
                 </option>
                 <option name="sortWeight" value="5000000" />
+              </folderState>
+              <folderState>
+                <option name="description" value="Ustalanie harmonogramu" />
+                <option name="folders">
+                  <list>
+                    <folderState>
+                      <option name="id" value="e711e00d-aad8-45f1-a78e-ff42cb669a38" />
+                      <option name="name" value="Player" />
+                      <option name="requests">
+                        <list>
+                          <requestState>
+                            <option name="body">
+                              <bodyState>
+                                <option name="raw" value="{&#10;  &quot;schedulerId&quot;: 2,&#10;  &quot;slots&quot;: [&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2025-12-20T18:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2025-12-20T22:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;YES&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2025-12-21T19:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2025-12-21T23:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;YES&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2025-12-27T18:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2025-12-27T21:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;NO&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2025-12-28T19:30:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2025-12-28T23:30:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;NO&quot;&#10;    }&#10;  ]&#10;}" />
+                                <option name="type" value="JSON" />
+                              </bodyState>
+                            </option>
+                            <option name="description" value="Prześlij swoją dyspozycję" />
+                            <option name="id" value="e420a0d7-e1b8-41bf-819b-dadb45481c8c" />
+                            <option name="method" value="POST" />
+                            <option name="name" value="Submit Availability" />
+                            <option name="sortWeight" value="1000000" />
+                            <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/submitAvailability" />
+                          </requestState>
+                          <requestState>
+                            <option name="description" value="Pobierz dostępność dla danego gracza" />
+                            <option name="id" value="a6ae3328-f5d3-496d-914c-a8e026a89f05" />
+                            <option name="method" value="GET" />
+                            <option name="name" value="Get Player Availability" />
+                            <option name="pathVariables">
+                              <list>
+                                <pathVariableState>
+                                  <option name="key" value="schedulerId" />
+                                  <option name="value" value="2" />
+                                </pathVariableState>
+                              </list>
+                            </option>
+                            <option name="sortWeight" value="2000000" />
+                            <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/availability/{schedulerId}" />
+                          </requestState>
+                        </list>
+                      </option>
+                      <option name="sortWeight" value="1000000" />
+                    </folderState>
+                  </list>
+                </option>
+                <option name="id" value="7c2346a8-d9e5-4535-84fa-3ae4cbc5edea" />
+                <option name="name" value="Scheduler" />
+                <option name="requests">
+                  <list>
+                    <requestState>
+                      <option name="body">
+                        <bodyState>
+                          <option name="raw" value="{&#10;  &quot;title&quot;: &quot;Spotkanie RPG: Początek Kampanii&quot;,&#10;  &quot;deadline&quot;: &quot;2026-12-15T23:59:59&quot;,&#10;  &quot;minimumSessionDurationMinutes&quot;: 60,&#10;  &quot;gameId&quot;: 1,&#10;  &quot;creatorId&quot;: 1,&#10;  &quot;dateRanges&quot;: [&#10;    {&#10;      &quot;startDate&quot;: &quot;2025-12-20&quot;,&#10;      &quot;endDate&quot;: &quot;2025-12-22&quot;,&#10;      &quot;startTime&quot;: &quot;18:00:00&quot;,&#10;      &quot;endTime&quot;: &quot;22:00:00&quot;&#10;    },&#10;    {&#10;      &quot;startDate&quot;: &quot;2025-12-27&quot;,&#10;      &quot;endDate&quot;: &quot;2025-12-28&quot;,&#10;      &quot;startTime&quot;: &quot;19:00:00&quot;,&#10;      &quot;endTime&quot;: &quot;23:30:00&quot;&#10;    }&#10;  ],&#10;  &quot;participantIds&quot;: [1, 2]&#10;}" />
+                          <option name="type" value="JSON" />
+                        </bodyState>
+                      </option>
+                      <option name="description" value="Utwórz przykładowy scheduler" />
+                      <option name="id" value="256737f5-74ba-47ac-abba-47305aaff9f9" />
+                      <option name="method" value="POST" />
+                      <option name="name" value="Create Scheduler" />
+                      <option name="sortWeight" value="500000" />
+                      <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/create" />
+                    </requestState>
+                    <requestState>
+                      <option name="description" value="Pobierz scheduler po id" />
+                      <option name="id" value="9d7e0c51-6c4a-4f34-9c2f-1999b00c1114" />
+                      <option name="method" value="GET" />
+                      <option name="name" value="Get Scheduler" />
+                      <option name="sortWeight" value="1000000" />
+                      <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/forGame/1" />
+                    </requestState>
+                    <requestState>
+                      <option name="description" value="Pobierz schedulery dla konkretnej gry" />
+                      <option name="id" value="73d75294-bb3b-42df-990b-cfbbf77782de" />
+                      <option name="method" value="GET" />
+                      <option name="name" value="Get Scheduler for Game" />
+                      <option name="pathVariables">
+                        <list>
+                          <pathVariableState>
+                            <option name="key" value="schedulerId" />
+                            <option name="value" value="2" />
+                          </pathVariableState>
+                        </list>
+                      </option>
+                      <option name="sortWeight" value="1500000" />
+                      <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/{schedulerId}" />
+                    </requestState>
+                    <requestState>
+                      <option name="body">
+                        <bodyState>
+                          <option name="raw" value="{&#10;  &quot;schedulerId&quot;: 1,&#10;  &quot;title&quot;: &quot;Zmieniony tytuł sesji RPG&quot;,&#10;  &quot;deadline&quot;: &quot;2025-12-20T20:00:00&quot;,&#10;  &quot;minimumSessionDurationMinutes&quot;: 180,&#10;  &quot;dateRanges&quot;: [&#10;    {&#10;      &quot;startDate&quot;: &quot;2025-12-25&quot;,&#10;      &quot;endDate&quot;: &quot;2025-12-27&quot;,&#10;      &quot;startTime&quot;: &quot;18:00:00&quot;,&#10;      &quot;endTime&quot;: &quot;22:00:00&quot;&#10;    },&#10;    {&#10;      &quot;startDate&quot;: &quot;2025-12-30&quot;,&#10;      &quot;endDate&quot;: &quot;2025-12-31&quot;,&#10;      &quot;startTime&quot;: &quot;19:00:00&quot;,&#10;      &quot;endTime&quot;: &quot;23:30:00&quot;&#10;    }&#10;  ],&#10;  &quot;participantIds&quot;: [1, 2]&#10;}" />
+                          <option name="type" value="JSON" />
+                        </bodyState>
+                      </option>
+                      <option name="description" value="Zedytuj dany scheduler" />
+                      <option name="id" value="f7ee7d41-9dc5-4a7f-8918-6e4fee10a22f" />
+                      <option name="method" value="PUT" />
+                      <option name="name" value="Edit Scheduler" />
+                      <option name="sortWeight" value="3000000" />
+                      <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/edit" />
+                    </requestState>
+                    <requestState>
+                      <option name="description" value="Usuń scheduler o podanym id" />
+                      <option name="id" value="b177abc0-4582-47ae-a90f-1f9c16a2a556" />
+                      <option name="method" value="DELETE" />
+                      <option name="name" value="Delete Scheduler" />
+                      <option name="sortWeight" value="4000000" />
+                      <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/delete/1" />
+                    </requestState>
+                    <requestState>
+                      <option name="description" value="Pobierz sugerowane sloty przez program" />
+                      <option name="id" value="a9f966c8-32e3-4f1e-9dd8-0ae597975522" />
+                      <option name="method" value="GET" />
+                      <option name="name" value="Get Suggested Slots" />
+                      <option name="pathVariables">
+                        <list>
+                          <pathVariableState>
+                            <option name="key" value="schedulerId" />
+                            <option name="value" value="2" />
+                          </pathVariableState>
+                        </list>
+                      </option>
+                      <option name="sortWeight" value="5000000" />
+                      <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/suggestedSlots/{schedulerId}" />
+                    </requestState>
+                    <requestState>
+                      <option name="body">
+                        <bodyState>
+                          <option name="raw" value="{&#10;  &quot;schedulerId&quot;: 2,&#10;  &quot;start&quot;: &quot;2025-12-20T18:00:00&quot;,&#10;  &quot;end&quot;: &quot;2025-12-20T22:00:00&quot;&#10;}" />
+                          <option name="type" value="JSON" />
+                        </bodyState>
+                      </option>
+                      <option name="description" value="Ustal ostateczną datę spotkania" />
+                      <option name="id" value="ab3e209a-f04a-4fe3-b374-dfb27564e1c0" />
+                      <option name="method" value="PUT" />
+                      <option name="name" value="Set Final Decision" />
+                      <option name="sortWeight" value="6000000" />
+                      <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/setFinalDecision" />
+                    </requestState>
+                    <requestState>
+                      <option name="description" value="Wyślij maile po zakończeniu ustalniu terminów" />
+                      <option name="id" value="cd078805-8e84-44c8-a6af-1463eb3956dd" />
+                      <option name="method" value="POST" />
+                      <option name="name" value="Send Mails" />
+                      <option name="pathVariables">
+                        <list>
+                          <pathVariableState>
+                            <option name="key" value="schedulerId" />
+                            <option name="value" value="2" />
+                          </pathVariableState>
+                        </list>
+                      </option>
+                      <option name="sortWeight" value="7000000" />
+                      <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/sendFinalDecisionMails/{schedulerId}" />
+                    </requestState>
+                  </list>
+                </option>
+                <option name="sortWeight" value="6000000" />
               </folderState>
             </list>
           </option>

--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -496,7 +496,7 @@
                           <requestState>
                             <option name="body">
                               <bodyState>
-                                <option name="raw" value="{&#10;  &quot;schedulerId&quot;: 2,&#10;  &quot;slots&quot;: [&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2025-12-20T18:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2025-12-20T22:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;YES&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2025-12-21T19:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2025-12-21T23:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;YES&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2025-12-27T18:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2025-12-27T21:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;NO&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2025-12-28T19:30:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2025-12-28T23:30:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;NO&quot;&#10;    }&#10;  ]&#10;}" />
+                                <option name="raw" value="{&#10;  &quot;schedulerId&quot;: 1,&#10;  &quot;slots&quot;: [&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2025-12-20T18:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2025-12-20T22:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;YES&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2025-12-21T19:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2025-12-21T23:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;MAYBE&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2025-12-27T18:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2025-12-27T21:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;NO&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2025-12-28T19:30:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2025-12-28T23:30:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;NO&quot;&#10;    }&#10;  ]&#10;}" />
                                 <option name="type" value="JSON" />
                               </bodyState>
                             </option>
@@ -508,25 +508,9 @@
                             <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/submitAvailability" />
                           </requestState>
                           <requestState>
-                            <option name="description" value="Pobierz dostępność dla danego gracza" />
-                            <option name="id" value="a6ae3328-f5d3-496d-914c-a8e026a89f05" />
-                            <option name="method" value="GET" />
-                            <option name="name" value="Get Player Availability" />
-                            <option name="pathVariables">
-                              <list>
-                                <pathVariableState>
-                                  <option name="key" value="schedulerId" />
-                                  <option name="value" value="2" />
-                                </pathVariableState>
-                              </list>
-                            </option>
-                            <option name="sortWeight" value="2000000" />
-                            <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/availability/{schedulerId}" />
-                          </requestState>
-                          <requestState>
                             <option name="body">
                               <bodyState>
-                                <option name="raw" value="{&#10;  &quot;schedulerId&quot;: 1,&#10;  &quot;slots&quot;: [&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2023-12-20T17:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2023-12-20T21:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;YES&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2023-12-22T19:30:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2023-12-22T23:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;YES&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2023-12-25T15:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2023-12-25T19:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;MAYBE&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2023-12-29T18:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2023-12-29T22:30:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;NO&quot;&#10;    }&#10;  ]&#10;}" />
+                                <option name="raw" value="{&#10;  &quot;schedulerId&quot;: 1,&#10;  &quot;slots&quot;: [&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2025-12-20T18:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2025-12-20T22:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;YES&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2025-12-21T19:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2025-12-21T23:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;MAYBE&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2025-12-27T18:00:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2025-12-27T21:00:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;NO&quot;&#10;    },&#10;    {&#10;      &quot;startDateTime&quot;: &quot;2025-12-28T19:30:00&quot;,&#10;      &quot;endDateTime&quot;: &quot;2025-12-28T23:30:00&quot;,&#10;      &quot;availabilityType&quot;: &quot;NO&quot;&#10;    }&#10;  ]&#10;}" />
                                 <option name="type" value="JSON" />
                               </bodyState>
                             </option>
@@ -536,6 +520,37 @@
                             <option name="name" value="Edit Availability" />
                             <option name="sortWeight" value="3000000" />
                             <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/editAvailability" />
+                          </requestState>
+                          <requestState>
+                            <option name="description" value="Pobierz dostępność dla schedulera dla konkretnego użytkownika" />
+                            <option name="id" value="a6ae3328-f5d3-496d-914c-a8e026a89f05" />
+                            <option name="method" value="GET" />
+                            <option name="name" value="Get Player Availability" />
+                            <option name="pathVariables">
+                              <list>
+                                <pathVariableState>
+                                  <option name="key" value="schedulerId" />
+                                  <option name="value" value="1" />
+                                </pathVariableState>
+                              </list>
+                            </option>
+                            <option name="sortWeight" value="4000000" />
+                            <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/availability/{schedulerId}" />
+                          </requestState>
+                          <requestState>
+                            <option name="description" value="Pobierz scheduler po id" />
+                            <option name="id" value="9d7e0c51-6c4a-4f34-9c2f-1999b00c1114" />
+                            <option name="method" value="GET" />
+                            <option name="name" value="Get Scheduler" />
+                            <option name="pathVariables">
+                              <list>
+                                <pathVariableState>
+                                  <option name="key" value="schedulerId" />
+                                </pathVariableState>
+                              </list>
+                            </option>
+                            <option name="sortWeight" value="5000000" />
+                            <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/{schedulerId}" />
                           </requestState>
                         </list>
                       </option>
@@ -550,7 +565,7 @@
                     <requestState>
                       <option name="body">
                         <bodyState>
-                          <option name="raw" value="{&#10;  &quot;title&quot;: &quot;Spotkanie RPG: Początek Kampanii&quot;,&#10;  &quot;deadline&quot;: &quot;2026-12-15T23:59:59&quot;,&#10;  &quot;minimumSessionDurationMinutes&quot;: 60,&#10;  &quot;gameId&quot;: 1,&#10;  &quot;creatorId&quot;: 1,&#10;  &quot;dateRanges&quot;: [&#10;    {&#10;      &quot;startDate&quot;: &quot;2025-12-20&quot;,&#10;      &quot;endDate&quot;: &quot;2025-12-22&quot;,&#10;      &quot;startTime&quot;: &quot;18:00:00&quot;,&#10;      &quot;endTime&quot;: &quot;22:00:00&quot;&#10;    },&#10;    {&#10;      &quot;startDate&quot;: &quot;2025-12-27&quot;,&#10;      &quot;endDate&quot;: &quot;2025-12-28&quot;,&#10;      &quot;startTime&quot;: &quot;19:00:00&quot;,&#10;      &quot;endTime&quot;: &quot;23:30:00&quot;&#10;    }&#10;  ],&#10;  &quot;participantIds&quot;: [1, 2]&#10;}" />
+                          <option name="raw" value="{&#10;  &quot;title&quot;: &quot;Spotkanie RPG: Początek Kampanii&quot;,&#10;  &quot;deadline&quot;: &quot;2026-12-15T23:59:59&quot;,&#10;  &quot;minimumSessionDurationMinutes&quot;: 60,&#10;  &quot;gameId&quot;: 1,&#10;  &quot;creatorId&quot;: 1,&#10;  &quot;dateRanges&quot;: [&#10;    {&#10;      &quot;startDate&quot;: &quot;2025-12-20&quot;,&#10;      &quot;endDate&quot;: &quot;2025-12-22&quot;&#10;    },&#10;    {&#10;      &quot;startDate&quot;: &quot;2025-12-27&quot;,&#10;      &quot;endDate&quot;: &quot;2025-12-28&quot;&#10;    }&#10;  ],&#10;  &quot;timeRanges&quot;: [&#10;    {&#10;      &quot;startTime&quot;: &quot;18:00:00&quot;,&#10;      &quot;endTime&quot;: &quot;22:00:00&quot;&#10;    },&#10;    {&#10;      &quot;startTime&quot;: &quot;19:00:00&quot;,&#10;      &quot;endTime&quot;: &quot;23:30:00&quot;&#10;    }&#10;  ],&#10;  &quot;participantIds&quot;: [1, 2]&#10;}" />
                           <option name="type" value="JSON" />
                         </bodyState>
                       </option>
@@ -560,21 +575,6 @@
                       <option name="name" value="Create Scheduler" />
                       <option name="sortWeight" value="500000" />
                       <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/create" />
-                    </requestState>
-                    <requestState>
-                      <option name="description" value="Pobierz scheduler po id" />
-                      <option name="id" value="9d7e0c51-6c4a-4f34-9c2f-1999b00c1114" />
-                      <option name="method" value="GET" />
-                      <option name="name" value="Get Scheduler" />
-                      <option name="pathVariables">
-                        <list>
-                          <pathVariableState>
-                            <option name="key" value="schedulerId" />
-                          </pathVariableState>
-                        </list>
-                      </option>
-                      <option name="sortWeight" value="1000000" />
-                      <option name="url" value="http://localhost:8888/api/v1/authorized/schedulers/{schedulerId}" />
                     </requestState>
                     <requestState>
                       <option name="description" value="Pobierz schedulery dla konkretnej gry" />
@@ -587,7 +587,7 @@
                     <requestState>
                       <option name="body">
                         <bodyState>
-                          <option name="raw" value="{&#10;  &quot;schedulerId&quot;: 1,&#10;  &quot;title&quot;: &quot;Zmieniony tytuł sesji RPG&quot;,&#10;  &quot;deadline&quot;: &quot;2025-12-20T20:00:00&quot;,&#10;  &quot;minimumSessionDurationMinutes&quot;: 180,&#10;  &quot;dateRanges&quot;: [&#10;    {&#10;      &quot;startDate&quot;: &quot;2025-12-25&quot;,&#10;      &quot;endDate&quot;: &quot;2025-12-27&quot;,&#10;      &quot;startTime&quot;: &quot;18:00:00&quot;,&#10;      &quot;endTime&quot;: &quot;22:00:00&quot;&#10;    },&#10;    {&#10;      &quot;startDate&quot;: &quot;2025-12-30&quot;,&#10;      &quot;endDate&quot;: &quot;2025-12-31&quot;,&#10;      &quot;startTime&quot;: &quot;19:00:00&quot;,&#10;      &quot;endTime&quot;: &quot;23:30:00&quot;&#10;    }&#10;  ],&#10;  &quot;participantIds&quot;: [1, 2]&#10;}" />
+                          <option name="raw" value="{&#10;  &quot;schedulerId&quot;: 1,&#10;  &quot;title&quot;: &quot;Zmieniony tytuł sesji RPG&quot;,&#10;  &quot;deadline&quot;: &quot;2025-12-20T20:00:00&quot;,&#10;  &quot;minimumSessionDurationMinutes&quot;: 180,&#10;  &quot;dateRanges&quot;: [&#10;    {&#10;      &quot;startDate&quot;: &quot;2025-12-25&quot;,&#10;      &quot;endDate&quot;: &quot;2025-12-27&quot;&#10;    },&#10;    {&#10;      &quot;startDate&quot;: &quot;2025-12-30&quot;,&#10;      &quot;endDate&quot;: &quot;2025-12-31&quot;&#10;    }&#10;  ],&#10;  &quot;timeRanges&quot;: [&#10;    {&#10;      &quot;startTime&quot;: &quot;18:00:00&quot;,&#10;      &quot;endTime&quot;: &quot;22:00:00&quot;&#10;    },&#10;    {&#10;      &quot;startTime&quot;: &quot;19:00:00&quot;,&#10;      &quot;endTime&quot;: &quot;23:30:00&quot;&#10;    }&#10;  ],&#10;  &quot;participantIds&quot;: [1, 2]&#10;}" />
                           <option name="type" value="JSON" />
                         </bodyState>
                       </option>
@@ -615,7 +615,7 @@
                         <list>
                           <pathVariableState>
                             <option name="key" value="schedulerId" />
-                            <option name="value" value="2" />
+                            <option name="value" value="1" />
                           </pathVariableState>
                         </list>
                       </option>

--- a/src/main/java/dev/goral/rpgmanager/email/EmailService.java
+++ b/src/main/java/dev/goral/rpgmanager/email/EmailService.java
@@ -129,6 +129,10 @@ public class EmailService {
             String email = participant.getPlayer().getEmail();
             if (email == null || email.isBlank()) continue;
 
+            if (scheduler.getFinalDecision() == null) {
+                throw new IllegalStateException("Final decision is not set for the scheduler.");
+            }
+
             String subject = "Potwierdzono termin sesji | RPG Handy Helper";
             String htmlContent = generateFinalDecisionEmailTemplate(
                     participant.getPlayer().getUsername(),

--- a/src/main/java/dev/goral/rpgmanager/email/EmailService.java
+++ b/src/main/java/dev/goral/rpgmanager/email/EmailService.java
@@ -125,13 +125,14 @@ public class EmailService {
     }
 
     public void sendFinalDecisionNotification(Scheduler scheduler) {
+
+        if (scheduler.getFinalDecision() == null) {
+            throw new IllegalStateException("Nie ustanowiono jeszcze głównego terminu spotkania.");
+        }
+
         for (SchedulerParticipant participant : scheduler.getParticipants()) {
             String email = participant.getPlayer().getEmail();
             if (email == null || email.isBlank()) continue;
-
-            if (scheduler.getFinalDecision() == null) {
-                throw new IllegalStateException("Final decision is not set for the scheduler.");
-            }
 
             String subject = "Potwierdzono termin sesji | RPG Handy Helper";
             String htmlContent = generateFinalDecisionEmailTemplate(

--- a/src/main/java/dev/goral/rpgmanager/email/EmailService.java
+++ b/src/main/java/dev/goral/rpgmanager/email/EmailService.java
@@ -171,7 +171,7 @@ public class EmailService {
                 <p>Twoja sesja <strong>%s</strong> została zaplanowana:</p>
                 <p><strong>%s – %s</strong></p>
                 <p>Dodaj wydarzenie do swojego kalendarza:</p>
-                <p><a href="%s" class="button">Dodaj do Google Kalendarza</a></p>
+                <p><a href="%s" class="button">Dodaj do Kalendarza Google</a></p>
                 <hr>
                 <p><strong>RPG Handy Helper Team</strong></p>
             </body>

--- a/src/main/java/dev/goral/rpgmanager/email/EmailService.java
+++ b/src/main/java/dev/goral/rpgmanager/email/EmailService.java
@@ -1,5 +1,7 @@
 package dev.goral.rpgmanager.email;
 
+import dev.goral.rpgmanager.scheduler.entity.Scheduler;
+import dev.goral.rpgmanager.scheduler.entity.SchedulerParticipant;
 import dev.goral.rpgmanager.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,6 +11,9 @@ import org.springframework.stereotype.Service;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Service
 @RequiredArgsConstructor
@@ -54,11 +59,11 @@ public class EmailService {
                 <meta name="viewport" content="width=device-width, initial-scale=1.0">
                 <title>Aktywacja Konta</title>
                 <style>
-                    body { background-color: #070d29; color: #f3f4f4; font-family: Arial, sans-serif; text-align: center; padding: 20px; }
+                    body { background-color: #1e1e1e; color: #f3f4f4; font-family: Arial, sans-serif; text-align: center; padding: 20px; }
                     h1 { color: #12e1b9; }
                     p { font-size: 18px; line-height: 1.5; }
                     .button {
-                        display: inline-block; background-color: #12e1b9; color: #070d29;
+                        display: inline-block; background-color: #12e1b9; color: #1e1e1e;
                         padding: 10px 20px; border-radius: 4px; text-decoration: none;
                         font-size: 18px; font-weight: bold;
                     }
@@ -95,11 +100,11 @@ public class EmailService {
                 <meta name="viewport" content="width=device-width, initial-scale=1.0">
                 <title>Resetowanie Hasła</title>
                 <style>
-                    body { background-color: #070d29; color: #f3f4f4; font-family: Arial, sans-serif; text-align: center; padding: 20px; }
+                    body { background-color: #1e1e1e; color: #f3f4f4; font-family: Arial, sans-serif; text-align: center; padding: 20px; }
                     h1 { color: #12e1b9; }
                     p { font-size: 18px; line-height: 1.5; }
                     .button {
-                        display: inline-block; background-color: #12e1b9; color: #070d29;
+                        display: inline-block; background-color: #12e1b9; color: #1e1e1e;
                         padding: 10px 20px; border-radius: 4px; text-decoration: none;
                         font-size: 18px; font-weight: bold;
                     }
@@ -118,4 +123,61 @@ public class EmailService {
                 </html>
                 """.formatted(resetUrl);
     }
+
+    public void sendFinalDecisionNotification(Scheduler scheduler) {
+        for (SchedulerParticipant participant : scheduler.getParticipants()) {
+            String email = participant.getPlayer().getEmail();
+            if (email == null || email.isBlank()) continue;
+
+            String subject = "Potwierdzono termin sesji | RPG Handy Helper";
+            String htmlContent = generateFinalDecisionEmailTemplate(
+                    participant.getPlayer().getUsername(),
+                    scheduler.getTitle(),
+                    scheduler.getFinalDecision().getStart(),
+                    scheduler.getFinalDecision().getEnd(),
+                    scheduler.getGoogleCalendarLink()
+            );
+
+            sendEmail(email, subject, htmlContent);
+        }
+    }
+
+    private String generateFinalDecisionEmailTemplate(String username, String title, LocalDateTime start, LocalDateTime end, String calendarLink) {
+        String formattedStart = start.format(DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm"));
+        String formattedEnd = end.format(DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm"));
+
+        return """
+            <!DOCTYPE html>
+            <html lang="pl">
+            <head>
+                <meta charset="UTF-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <title>Termin Sesji</title>
+                <style>
+                    body { background-color: #1e1e1e; color: #f3f4f4; font-family: Arial, sans-serif; text-align: center; padding: 20px; }
+                    h1 { color: #12e1b9; }
+                    p { font-size: 18px; line-height: 1.5; }
+                    .button {
+                        display: inline-block; background-color: #12e1b9; color: #1e1e1e;
+                        padding: 10px 20px; border-radius: 4px; text-decoration: none;
+                        font-size: 18px; font-weight: bold;
+                    }
+                </style>
+            </head>
+            <body>
+                <img src="https://github.com/xEdziu/RPG-Handy-Helper/raw/main/banner-rpg.png" alt="Logo" width="500">
+                <h1>TERMIN SESJI POTWIERDZONY</h1>
+                <p>Cześć %s!</p>
+                <p>Twoja sesja <strong>%s</strong> została zaplanowana:</p>
+                <p><strong>%s – %s</strong></p>
+                <p>Dodaj wydarzenie do swojego kalendarza:</p>
+                <p><a href="%s" class="button">Dodaj do Google Kalendarza</a></p>
+                <hr>
+                <p><strong>RPG Handy Helper Team</strong></p>
+            </body>
+            </html>
+            """.formatted(username, title, formattedStart, formattedEnd, calendarLink);
+    }
+
+
 }

--- a/src/main/java/dev/goral/rpgmanager/email/EmailService.java
+++ b/src/main/java/dev/goral/rpgmanager/email/EmailService.java
@@ -179,5 +179,53 @@ public class EmailService {
             """.formatted(username, title, formattedStart, formattedEnd, calendarLink);
     }
 
+    public void sendSchedulerCreatedNotification(Scheduler scheduler) {
+        for (SchedulerParticipant participant : scheduler.getParticipants()) {
+            String email = participant.getPlayer().getEmail();
+            if (email == null || email.isBlank()) continue;
+
+            String subject = "Nowy terminarz sesji RPG | RPG Handy Helper";
+
+            String htmlContent = generateSchedulerCreatedEmailTemplate(
+                    participant.getPlayer().getUsername(),
+                    scheduler.getTitle(),
+                    scheduler.getDeadline()
+            );
+
+            sendEmail(email, subject, htmlContent);
+        }
+    }
+
+    private String generateSchedulerCreatedEmailTemplate(String username, String title, LocalDateTime deadline) {
+        String formattedDeadline = deadline.format(DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm"));
+
+        return """
+            <!DOCTYPE html>
+            <html lang="pl">
+            <head>
+                <meta charset="UTF-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <title>Nowy Terminarz</title>
+                <style>
+                    body { background-color: #1e1e1e; color: #f3f4f4; font-family: Arial, sans-serif; text-align: center; padding: 20px; }
+                    h1 { color: #12e1b9; }
+                    p { font-size: 18px; line-height: 1.5; }
+                </style>
+            </head>
+            <body>
+                <img src="https://github.com/xEdziu/RPG-Handy-Helper/raw/main/banner-rpg.png" alt="Logo" width="500">
+                <h1>NOWY TERMINARZ SESJI</h1>
+                <p>Cześć %s!</p>
+                <p>GameMaster właśnie utworzył nowy terminarz sesji: <strong>%s</strong>.</p>
+                <p>Prosimy, uzupełnij swoją dostępność do <strong>%s</strong>.</p>
+                <hr>
+                <p><strong>RPG Handy Helper Team</strong></p>
+            </body>
+            </html>
+            """.formatted(username, title, formattedDeadline);
+    }
+
+
+
 
 }

--- a/src/main/java/dev/goral/rpgmanager/email/EmailService.java
+++ b/src/main/java/dev/goral/rpgmanager/email/EmailService.java
@@ -24,9 +24,6 @@ public class EmailService {
     @Value("${baseUrl}")
     private String baseUrl;
 
-    @Value("${spring.mail.username}")
-    private String fromMail;
-
     public void sendVerificationEmail(User user) {
         String subject = "Aktywacja Konta | RPG Handy Helper";
         String confirmationUrl = baseUrl + "/activate?token=" + user.getToken();
@@ -39,11 +36,11 @@ public class EmailService {
         try {
             MimeMessage message = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
-
+            String setFromMail = String.format("%s <%s>", "RPG Handy Helper Team", "rpg@adrian-goral.dev");
             helper.setTo(to);
             helper.setSubject(subject);
             helper.setText(htmlContent, true);
-            helper.setFrom(fromMail);
+            message.setFrom(setFromMail);
             mailSender.send(message);
         } catch (MessagingException e) {
             throw new IllegalStateException("Failed to send email", e);

--- a/src/main/java/dev/goral/rpgmanager/game/Game.java
+++ b/src/main/java/dev/goral/rpgmanager/game/Game.java
@@ -3,8 +3,12 @@ package dev.goral.rpgmanager.game;
 
 import dev.goral.rpgmanager.user.User;
 import dev.goral.rpgmanager.rpgSystems.RpgSystems;
+import dev.goral.rpgmanager.scheduler.entity.Scheduler;
+import java.util.List;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
 
 @Entity
 @Table
@@ -46,6 +50,11 @@ public class Game {
             nullable = false
     )
     private RpgSystems rpgSystem;
+
+    @OneToMany(mappedBy = "game", cascade = CascadeType.ALL, orphanRemoval = true)
+    @ToString.Exclude
+    private List<Scheduler> schedulers = new ArrayList<>();
+
 
     @Enumerated(EnumType.STRING)
     private GameStatus status = GameStatus.ACTIVE;

--- a/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
@@ -1,0 +1,76 @@
+package dev.goral.rpgmanager.scheduler.controller;
+
+import dev.goral.rpgmanager.scheduler.dto.request.CreateSchedulerRequest;
+import dev.goral.rpgmanager.scheduler.dto.request.SetFinalDecisionRequest;
+import dev.goral.rpgmanager.scheduler.dto.response.SchedulerResponse;
+import dev.goral.rpgmanager.scheduler.service.SchedulerService;
+import dev.goral.rpgmanager.security.CustomReturnables;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/authorized/schedulers")
+@RequiredArgsConstructor
+public class SchedulerController {
+
+    private final SchedulerService schedulerService;
+
+    @PostMapping("/create")
+    public Map<String, Object> createScheduler(
+            @RequestBody CreateSchedulerRequest request,
+            @AuthenticationPrincipal Principal principal
+    ) {
+        SchedulerResponse scheduler = schedulerService.createScheduler(request, principal);
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Utworzono harmonogram.");
+        response.put("scheduler", scheduler);
+        return response;
+    }
+
+    @GetMapping("/forGame/{gameId}")
+    public Map<String, Object> getSchedulersByGame(
+            @PathVariable Long gameId,
+            @AuthenticationPrincipal Principal principal
+    ) {
+        List<SchedulerResponse> schedulers = schedulerService.getSchedulersByGame(gameId, principal);
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano listę harmonogramów.");
+        response.put("schedulers", schedulers);
+        return response;
+    }
+
+    @GetMapping("/{schedulerId}")
+    public Map<String, Object> getSchedulerById(
+            @PathVariable Long schedulerId,
+            @AuthenticationPrincipal Principal principal
+    ) {
+        SchedulerResponse scheduler = schedulerService.getSchedulerById(schedulerId, principal);
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano harmonogram.");
+        response.put("scheduler", scheduler);
+        return response;
+    }
+
+    @DeleteMapping("/delete/{schedulerId}")
+    public Map<String, Object> deleteScheduler(
+            @PathVariable Long schedulerId,
+            @AuthenticationPrincipal Principal principal
+    ) {
+        schedulerService.deleteScheduler(schedulerId, principal);
+        return CustomReturnables.getOkResponseMap("Scheduler został usunięty.");
+    }
+
+    @PutMapping("/setFinalDecision")
+    public Map<String, Object> setFinalDecision(
+            @RequestBody SetFinalDecisionRequest request,
+            @AuthenticationPrincipal Principal principal
+    ) {
+        SchedulerResponse updated = schedulerService.setFinalDecision(request, principal);
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Ustawiono ostateczny termin.");
+        response.put("scheduler", updated);
+        return response;
+    }
+
+}

--- a/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
@@ -3,6 +3,7 @@ package dev.goral.rpgmanager.scheduler.controller;
 import dev.goral.rpgmanager.scheduler.dto.request.CreateSchedulerRequest;
 import dev.goral.rpgmanager.scheduler.dto.request.SetFinalDecisionRequest;
 import dev.goral.rpgmanager.scheduler.dto.request.SubmitAvailabilityRequest;
+import dev.goral.rpgmanager.scheduler.dto.response.PlayerAvailabilityResponse;
 import dev.goral.rpgmanager.scheduler.dto.response.SchedulerResponse;
 import dev.goral.rpgmanager.scheduler.service.SchedulerService;
 import dev.goral.rpgmanager.security.CustomReturnables;
@@ -20,6 +21,11 @@ import java.util.Map;
 public class SchedulerController {
 
     private final SchedulerService schedulerService;
+
+    /*
+     =========================== SCHEDULER ===========================
+     */
+
 
     @PostMapping("/create")
     public Map<String, Object> createScheduler(
@@ -74,6 +80,10 @@ public class SchedulerController {
         return response;
     }
 
+    /*
+     =========================== PLAYER AVAILABILITY ===========================
+     */
+
     @PostMapping("/submitAvailability")
     public Map<String, Object> submitAvailability(
             @RequestBody SubmitAvailabilityRequest request,
@@ -83,5 +93,15 @@ public class SchedulerController {
         return CustomReturnables.getOkResponseMap("Dostępność została zapisana.");
     }
 
+    @GetMapping("/availability/{schedulerId}")
+    public Map<String, Object> getPlayerAvailability(
+            @PathVariable Long schedulerId,
+            @AuthenticationPrincipal Principal principal
+    ) {
+        PlayerAvailabilityResponse responseData = schedulerService.getPlayerAvailability(schedulerId, principal);
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano dostępność gracza.");
+        response.put("availability", responseData);
+        return response;
+    }
 
 }

--- a/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
@@ -1,6 +1,7 @@
 package dev.goral.rpgmanager.scheduler.controller;
 
 import dev.goral.rpgmanager.scheduler.dto.request.CreateSchedulerRequest;
+import dev.goral.rpgmanager.scheduler.dto.request.EditSchedulerRequest;
 import dev.goral.rpgmanager.scheduler.dto.request.SetFinalDecisionRequest;
 import dev.goral.rpgmanager.scheduler.dto.request.SubmitAvailabilityRequest;
 import dev.goral.rpgmanager.scheduler.dto.response.PlayerAvailabilityResponse;
@@ -60,6 +61,18 @@ public class SchedulerController {
         response.put("scheduler", scheduler);
         return response;
     }
+
+    @PutMapping("/edit")
+    public Map<String, Object> editScheduler(
+            @RequestBody EditSchedulerRequest request,
+            @AuthenticationPrincipal Principal principal
+    ) {
+        SchedulerResponse scheduler = schedulerService.editScheduler(request, principal);
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Zaktualizowano scheduler.");
+        response.put("scheduler", scheduler);
+        return response;
+    }
+
 
     @DeleteMapping("/delete/{schedulerId}")
     public Map<String, Object> deleteScheduler(

--- a/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
@@ -147,4 +147,15 @@ public class SchedulerController {
         return response;
     }
 
+    @GetMapping("/availability/{schedulerId}/all")
+    public Map<String, Object> getAllPlayerAvailability(
+            @PathVariable Long schedulerId,
+            @AuthenticationPrincipal User currentUser
+    ) {
+        List<PlayerAvailabilityResponse> responseData = schedulerService.getAllPlayerAvailability(schedulerId, currentUser);
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano dostępność graczy.");
+        response.put("availability", responseData);
+        return response;
+    }
+
 }

--- a/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
@@ -127,6 +127,15 @@ public class SchedulerController {
         return CustomReturnables.getOkResponseMap("Dostępność została zapisana.");
     }
 
+    @PutMapping("/editAvailability")
+    public Map<String, Object> editAvailability(
+            @RequestBody SubmitAvailabilityRequest request,
+            @AuthenticationPrincipal User currentUser
+    ) {
+        schedulerService.editAvailability(request, currentUser);
+        return CustomReturnables.getOkResponseMap("Dostępność została zaktualizowana.");
+    }
+
     @GetMapping("/availability/{schedulerId}")
     public Map<String, Object> getPlayerAvailability(
             @PathVariable Long schedulerId,

--- a/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
@@ -9,11 +9,10 @@ import dev.goral.rpgmanager.scheduler.dto.response.SchedulerResponse;
 import dev.goral.rpgmanager.scheduler.dto.response.SuggestedSlotResponse;
 import dev.goral.rpgmanager.scheduler.service.SchedulerService;
 import dev.goral.rpgmanager.security.CustomReturnables;
+import dev.goral.rpgmanager.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.security.Principal;
 import java.util.List;
 import java.util.Map;
 
@@ -32,9 +31,9 @@ public class SchedulerController {
     @PostMapping("/create")
     public Map<String, Object> createScheduler(
             @RequestBody CreateSchedulerRequest request,
-            @AuthenticationPrincipal Principal principal
+            @AuthenticationPrincipal User currentUser
     ) {
-        SchedulerResponse scheduler = schedulerService.createScheduler(request, principal);
+        SchedulerResponse scheduler = schedulerService.createScheduler(request, currentUser);
         Map<String, Object> response = CustomReturnables.getOkResponseMap("Utworzono harmonogram.");
         response.put("scheduler", scheduler);
         return response;
@@ -43,9 +42,9 @@ public class SchedulerController {
     @GetMapping("/forGame/{gameId}")
     public Map<String, Object> getSchedulersByGame(
             @PathVariable Long gameId,
-            @AuthenticationPrincipal Principal principal
+            @AuthenticationPrincipal User currentUser
     ) {
-        List<SchedulerResponse> schedulers = schedulerService.getSchedulersByGame(gameId, principal);
+        List<SchedulerResponse> schedulers = schedulerService.getSchedulersByGame(gameId, currentUser);
         Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano listę harmonogramów.");
         response.put("schedulers", schedulers);
         return response;
@@ -54,9 +53,9 @@ public class SchedulerController {
     @GetMapping("/{schedulerId}")
     public Map<String, Object> getSchedulerById(
             @PathVariable Long schedulerId,
-            @AuthenticationPrincipal Principal principal
+            @AuthenticationPrincipal User currentUser
     ) {
-        SchedulerResponse scheduler = schedulerService.getSchedulerById(schedulerId, principal);
+        SchedulerResponse scheduler = schedulerService.getSchedulerById(schedulerId, currentUser);
         Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano harmonogram.");
         response.put("scheduler", scheduler);
         return response;
@@ -65,9 +64,9 @@ public class SchedulerController {
     @PutMapping("/edit")
     public Map<String, Object> editScheduler(
             @RequestBody EditSchedulerRequest request,
-            @AuthenticationPrincipal Principal principal
+            @AuthenticationPrincipal User currentUser
     ) {
-        SchedulerResponse scheduler = schedulerService.editScheduler(request, principal);
+        SchedulerResponse scheduler = schedulerService.editScheduler(request, currentUser);
         Map<String, Object> response = CustomReturnables.getOkResponseMap("Zaktualizowano scheduler.");
         response.put("scheduler", scheduler);
         return response;
@@ -77,18 +76,18 @@ public class SchedulerController {
     @DeleteMapping("/delete/{schedulerId}")
     public Map<String, Object> deleteScheduler(
             @PathVariable Long schedulerId,
-            @AuthenticationPrincipal Principal principal
+            @AuthenticationPrincipal User currentUser
     ) {
-        schedulerService.deleteScheduler(schedulerId, principal);
+        schedulerService.deleteScheduler(schedulerId, currentUser);
         return CustomReturnables.getOkResponseMap("Scheduler został usunięty.");
     }
 
     @PutMapping("/setFinalDecision")
     public Map<String, Object> setFinalDecision(
             @RequestBody SetFinalDecisionRequest request,
-            @AuthenticationPrincipal Principal principal
+            @AuthenticationPrincipal User currentUser
     ) {
-        SchedulerResponse updated = schedulerService.setFinalDecision(request, principal);
+        SchedulerResponse updated = schedulerService.setFinalDecision(request, currentUser);
         Map<String, Object> response = CustomReturnables.getOkResponseMap("Ustawiono ostateczny termin.");
         response.put("scheduler", updated);
         return response;
@@ -97,9 +96,9 @@ public class SchedulerController {
     @GetMapping("/suggestedSlots/{schedulerId}")
     public Map<String, Object> suggestTimeSlots(
             @PathVariable Long schedulerId,
-            @AuthenticationPrincipal Principal principal
+            @AuthenticationPrincipal User currentUser
     ) {
-        SuggestedSlotResponse responseData = schedulerService.suggestTimeSlots(schedulerId, principal);
+        SuggestedSlotResponse responseData = schedulerService.suggestTimeSlots(schedulerId, currentUser);
         Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano proponowane przedziały.");
         response.put("suggestedSlots", responseData.getSuggestedSlots());
         return response;
@@ -108,9 +107,9 @@ public class SchedulerController {
     @PostMapping("/sendFinalDecisionMails/{schedulerId}")
     public Map<String, Object> sendFinalDecisionMails(
             @PathVariable Long schedulerId,
-            @AuthenticationPrincipal Principal principal
+            @AuthenticationPrincipal User currentUser
     ) {
-        schedulerService.sendFinalDecisionMails(schedulerId, principal);
+        schedulerService.sendFinalDecisionMails(schedulerId, currentUser);
         return CustomReturnables.getOkResponseMap("Wysłano wiadomości e-mail z potwierdzeniem terminu.");
     }
 
@@ -122,18 +121,18 @@ public class SchedulerController {
     @PostMapping("/submitAvailability")
     public Map<String, Object> submitAvailability(
             @RequestBody SubmitAvailabilityRequest request,
-            @AuthenticationPrincipal Principal principal
+            @AuthenticationPrincipal User currentUser
     ) {
-        schedulerService.submitAvailability(request, principal);
+        schedulerService.submitAvailability(request, currentUser);
         return CustomReturnables.getOkResponseMap("Dostępność została zapisana.");
     }
 
     @GetMapping("/availability/{schedulerId}")
     public Map<String, Object> getPlayerAvailability(
             @PathVariable Long schedulerId,
-            @AuthenticationPrincipal Principal principal
+            @AuthenticationPrincipal User currentUser
     ) {
-        PlayerAvailabilityResponse responseData = schedulerService.getPlayerAvailability(schedulerId, principal);
+        PlayerAvailabilityResponse responseData = schedulerService.getPlayerAvailability(schedulerId, currentUser);
         Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano dostępność gracza.");
         response.put("availability", responseData);
         return response;

--- a/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
@@ -5,6 +5,7 @@ import dev.goral.rpgmanager.scheduler.dto.request.SetFinalDecisionRequest;
 import dev.goral.rpgmanager.scheduler.dto.request.SubmitAvailabilityRequest;
 import dev.goral.rpgmanager.scheduler.dto.response.PlayerAvailabilityResponse;
 import dev.goral.rpgmanager.scheduler.dto.response.SchedulerResponse;
+import dev.goral.rpgmanager.scheduler.dto.response.SuggestedSlotResponse;
 import dev.goral.rpgmanager.scheduler.service.SchedulerService;
 import dev.goral.rpgmanager.security.CustomReturnables;
 import lombok.RequiredArgsConstructor;
@@ -79,6 +80,18 @@ public class SchedulerController {
         response.put("scheduler", updated);
         return response;
     }
+
+    @GetMapping("/suggestedSlots/{schedulerId}")
+    public Map<String, Object> suggestTimeSlots(
+            @PathVariable Long schedulerId,
+            @AuthenticationPrincipal Principal principal
+    ) {
+        SuggestedSlotResponse responseData = schedulerService.suggestTimeSlots(schedulerId, principal);
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano proponowane przedziały.");
+        response.put("suggestedSlots", responseData.getSuggestedSlots());
+        return response;
+    }
+
 
     /*
      =========================== PLAYER AVAILABILITY ===========================

--- a/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
@@ -2,6 +2,7 @@ package dev.goral.rpgmanager.scheduler.controller;
 
 import dev.goral.rpgmanager.scheduler.dto.request.CreateSchedulerRequest;
 import dev.goral.rpgmanager.scheduler.dto.request.SetFinalDecisionRequest;
+import dev.goral.rpgmanager.scheduler.dto.request.SubmitAvailabilityRequest;
 import dev.goral.rpgmanager.scheduler.dto.response.SchedulerResponse;
 import dev.goral.rpgmanager.scheduler.service.SchedulerService;
 import dev.goral.rpgmanager.security.CustomReturnables;
@@ -72,5 +73,15 @@ public class SchedulerController {
         response.put("scheduler", updated);
         return response;
     }
+
+    @PostMapping("/submitAvailability")
+    public Map<String, Object> submitAvailability(
+            @RequestBody SubmitAvailabilityRequest request,
+            @AuthenticationPrincipal Principal principal
+    ) {
+        schedulerService.submitAvailability(request, principal);
+        return CustomReturnables.getOkResponseMap("Dostępność została zapisana.");
+    }
+
 
 }

--- a/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/controller/SchedulerController.java
@@ -105,6 +105,15 @@ public class SchedulerController {
         return response;
     }
 
+    @PostMapping("/sendFinalDecisionMails/{schedulerId}")
+    public Map<String, Object> sendFinalDecisionMails(
+            @PathVariable Long schedulerId,
+            @AuthenticationPrincipal Principal principal
+    ) {
+        schedulerService.sendFinalDecisionMails(schedulerId, principal);
+        return CustomReturnables.getOkResponseMap("Wysłano wiadomości e-mail z potwierdzeniem terminu.");
+    }
+
 
     /*
      =========================== PLAYER AVAILABILITY ===========================

--- a/src/main/java/dev/goral/rpgmanager/scheduler/dto/common/TimeRangeDto.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/dto/common/TimeRangeDto.java
@@ -1,0 +1,13 @@
+package dev.goral.rpgmanager.scheduler.dto.common;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalTime;
+
+@Builder
+@Data
+public class TimeRangeDto {
+    private LocalTime startTime;
+    private LocalTime endTime;
+}

--- a/src/main/java/dev/goral/rpgmanager/scheduler/dto/request/CreateSchedulerRequest.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/dto/request/CreateSchedulerRequest.java
@@ -1,39 +1,34 @@
 package dev.goral.rpgmanager.scheduler.dto.request;
 
-import lombok.*;
+import dev.goral.rpgmanager.scheduler.dto.common.TimeRangeDto;
+import lombok.Data;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 
 /**
  * Request object for creating a new scheduler.
- * Contains the title, deadline, minimum session duration, game ID, creator ID,
- * date ranges, and participant IDs.
+ * <p>
+ * This class contains the necessary fields to create a new scheduler, including the title, deadline,
+ * minimum session duration, game ID, creator ID, date ranges, time ranges, and participant IDs.
+ * </p>
  */
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@Data
 public class CreateSchedulerRequest {
+
     private String title;
     private LocalDateTime deadline;
     private Integer minimumSessionDurationMinutes;
     private Long gameId;
     private Long creatorId;
     private List<DateRangeDto> dateRanges;
+    private List<TimeRangeDto> timeRanges;
     private List<Long> participantIds;
 
-    @Getter
-    @Setter
-    @NoArgsConstructor
-    @AllArgsConstructor
+    @Data
     public static class DateRangeDto {
         private LocalDate startDate;
         private LocalDate endDate;
-        private LocalTime startTime;
-        private LocalTime endTime;
     }
 }

--- a/src/main/java/dev/goral/rpgmanager/scheduler/dto/request/CreateSchedulerRequest.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/dto/request/CreateSchedulerRequest.java
@@ -1,0 +1,39 @@
+package dev.goral.rpgmanager.scheduler.dto.request;
+
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+/**
+ * Request object for creating a new scheduler.
+ * Contains the title, deadline, minimum session duration, game ID, creator ID,
+ * date ranges, and participant IDs.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateSchedulerRequest {
+    private String title;
+    private LocalDateTime deadline;
+    private Integer minimumSessionDurationMinutes;
+    private Long gameId;
+    private Long creatorId;
+    private List<DateRangeDto> dateRanges;
+    private List<Long> participantIds;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DateRangeDto {
+        private LocalDate startDate;
+        private LocalDate endDate;
+        private LocalTime startTime;
+        private LocalTime endTime;
+    }
+}

--- a/src/main/java/dev/goral/rpgmanager/scheduler/dto/request/EditSchedulerRequest.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/dto/request/EditSchedulerRequest.java
@@ -1,8 +1,11 @@
 package dev.goral.rpgmanager.scheduler.dto.request;
 
+import dev.goral.rpgmanager.scheduler.dto.common.TimeRangeDto;
+import lombok.*;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.*;
 
 @Getter
 @Setter
@@ -13,7 +16,13 @@ public class EditSchedulerRequest {
     private String title;
     private LocalDateTime deadline;
     private Integer minimumSessionDurationMinutes;
-    private List<CreateSchedulerRequest.DateRangeDto> dateRanges;
+    private List<DateRangeDto> dateRanges;
+    private List<TimeRangeDto> timeRanges;
     private List<Long> participantIds;
-}
 
+    @Data
+    public static class DateRangeDto {
+        private LocalDate startDate;
+        private LocalDate endDate;
+    }
+}

--- a/src/main/java/dev/goral/rpgmanager/scheduler/dto/request/EditSchedulerRequest.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/dto/request/EditSchedulerRequest.java
@@ -1,0 +1,19 @@
+package dev.goral.rpgmanager.scheduler.dto.request;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EditSchedulerRequest {
+    private Long schedulerId;
+    private String title;
+    private LocalDateTime deadline;
+    private Integer minimumSessionDurationMinutes;
+    private List<CreateSchedulerRequest.DateRangeDto> dateRanges;
+    private List<Long> participantIds;
+}
+

--- a/src/main/java/dev/goral/rpgmanager/scheduler/dto/request/SetFinalDecisionRequest.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/dto/request/SetFinalDecisionRequest.java
@@ -1,0 +1,18 @@
+package dev.goral.rpgmanager.scheduler.dto.request;
+
+import lombok.*;
+import java.time.LocalDateTime;
+
+/**
+ * Request object for setting the final decision in a scheduler.
+ * Contains the scheduler ID and the start and end times of the final decision.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SetFinalDecisionRequest {
+    private Long schedulerId;
+    private LocalDateTime start;
+    private LocalDateTime end;
+}

--- a/src/main/java/dev/goral/rpgmanager/scheduler/dto/request/SubmitAvailabilityRequest.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/dto/request/SubmitAvailabilityRequest.java
@@ -1,0 +1,31 @@
+package dev.goral.rpgmanager.scheduler.dto.request;
+
+import dev.goral.rpgmanager.scheduler.enums.AvailabilityType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Request object for submitting availability in a scheduler.
+ * Contains the scheduler ID, player ID, and a list of availability slots.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubmitAvailabilityRequest {
+    private Long schedulerId;
+    private Long playerId;
+    private List<AvailabilitySlotDto> slots;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AvailabilitySlotDto {
+        private LocalDateTime startDateTime;
+        private LocalDateTime endDateTime;
+        private AvailabilityType availabilityType;
+    }
+}

--- a/src/main/java/dev/goral/rpgmanager/scheduler/dto/response/PlayerAvailabilityResponse.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/dto/response/PlayerAvailabilityResponse.java
@@ -1,0 +1,30 @@
+package dev.goral.rpgmanager.scheduler.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import dev.goral.rpgmanager.scheduler.enums.AvailabilityType;
+import lombok.*;
+
+
+/**
+ * Response object for player availability in a scheduler.
+ * Contains the player ID and a list of availability slots.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlayerAvailabilityResponse {
+    private Long playerId;
+    private List<AvailabilitySlotDto> availability;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AvailabilitySlotDto {
+        private LocalDateTime startDateTime;
+        private LocalDateTime endDateTime;
+        private AvailabilityType availabilityType;
+    }
+}

--- a/src/main/java/dev/goral/rpgmanager/scheduler/dto/response/SchedulerResponse.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/dto/response/SchedulerResponse.java
@@ -4,6 +4,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+
+import dev.goral.rpgmanager.scheduler.enums.SchedulerStatus;
 import lombok.*;
 
 /*
@@ -29,6 +31,8 @@ public class SchedulerResponse {
     private List<DateRangeDto> dateRanges;
     private List<ParticipantDto> participants;
     private FinalDecisionDto finalDecision;
+    private SchedulerStatus status;
+    private int missingAvailabilitiesCount;
     private String googleCalendarLink;
 
     @Getter

--- a/src/main/java/dev/goral/rpgmanager/scheduler/dto/response/SchedulerResponse.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/dto/response/SchedulerResponse.java
@@ -8,14 +8,6 @@ import java.util.List;
 import dev.goral.rpgmanager.scheduler.enums.SchedulerStatus;
 import lombok.*;
 
-/*
- * SchedulerResponse.java
- *
- * This class represents the response object for a scheduler.
- * It contains information about the scheduler, including its ID,
- * title, deadline, minimum session duration, game ID, creator ID,
- * date ranges, participants, final decision, and Google Calendar link.
- */
 @Getter
 @Setter
 @NoArgsConstructor
@@ -29,6 +21,7 @@ public class SchedulerResponse {
     private Long gameId;
     private Long creatorId;
     private List<DateRangeDto> dateRanges;
+    private List<TimeRangeDto> timeRanges;
     private List<ParticipantDto> participants;
     private FinalDecisionDto finalDecision;
     private SchedulerStatus status;
@@ -43,6 +36,13 @@ public class SchedulerResponse {
     public static class DateRangeDto {
         private LocalDate startDate;
         private LocalDate endDate;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TimeRangeDto {
         private LocalTime startTime;
         private LocalTime endTime;
     }

--- a/src/main/java/dev/goral/rpgmanager/scheduler/dto/response/SchedulerResponse.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/dto/response/SchedulerResponse.java
@@ -1,0 +1,63 @@
+package dev.goral.rpgmanager.scheduler.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.*;
+
+/*
+ * SchedulerResponse.java
+ *
+ * This class represents the response object for a scheduler.
+ * It contains information about the scheduler, including its ID,
+ * title, deadline, minimum session duration, game ID, creator ID,
+ * date ranges, participants, final decision, and Google Calendar link.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SchedulerResponse {
+    private Long id;
+    private String title;
+    private LocalDateTime deadline;
+    private Integer minimumSessionDurationMinutes;
+    private Long gameId;
+    private Long creatorId;
+    private List<DateRangeDto> dateRanges;
+    private List<ParticipantDto> participants;
+    private FinalDecisionDto finalDecision;
+    private String googleCalendarLink;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DateRangeDto {
+        private LocalDate startDate;
+        private LocalDate endDate;
+        private LocalTime startTime;
+        private LocalTime endTime;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ParticipantDto {
+        private Long id;
+        private Long playerId;
+        private boolean notifiedByEmail;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FinalDecisionDto {
+        private LocalDateTime start;
+        private LocalDateTime end;
+    }
+}

--- a/src/main/java/dev/goral/rpgmanager/scheduler/dto/response/SchedulerResponse.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/dto/response/SchedulerResponse.java
@@ -34,6 +34,7 @@ public class SchedulerResponse {
     private SchedulerStatus status;
     private int missingAvailabilitiesCount;
     private String googleCalendarLink;
+    private boolean emailsSent;
 
     @Getter
     @Setter

--- a/src/main/java/dev/goral/rpgmanager/scheduler/dto/response/SuggestedSlotResponse.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/dto/response/SuggestedSlotResponse.java
@@ -1,0 +1,27 @@
+package dev.goral.rpgmanager.scheduler.dto.response;
+
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Represents a response containing suggested time slots for scheduling.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SuggestedSlotResponse {
+    private List<TimeSlotDto> suggestedSlots;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TimeSlotDto {
+        private LocalDateTime start;
+        private LocalDateTime end;
+        private int numberOfAvailableParticipants;
+    }
+}
+

--- a/src/main/java/dev/goral/rpgmanager/scheduler/dto/response/SuggestedSlotResponse.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/dto/response/SuggestedSlotResponse.java
@@ -21,7 +21,7 @@ public class SuggestedSlotResponse {
     public static class TimeSlotDto {
         private LocalDateTime start;
         private LocalDateTime end;
-        private int numberOfAvailableParticipants;
+        private double weightOfTimeSlot;
     }
 }
 

--- a/src/main/java/dev/goral/rpgmanager/scheduler/entity/AvailabilitySlot.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/entity/AvailabilitySlot.java
@@ -1,0 +1,40 @@
+package dev.goral.rpgmanager.scheduler.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import dev.goral.rpgmanager.scheduler.enums.AvailabilityType;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "availability_slots")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class AvailabilitySlot {
+
+    @Id
+    @SequenceGenerator(
+            name = "availability_slot_seq",
+            sequenceName = "availability_slot_seq",
+            allocationSize = 1
+    )
+    @GeneratedValue(
+            strategy = GenerationType.SEQUENCE,
+            generator = "availability_slot_seq"
+    )
+    private Long id;
+
+    private LocalDateTime startDateTime;
+    private LocalDateTime endDateTime;
+
+    @Enumerated(EnumType.STRING)
+    private AvailabilityType availabilityType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participant_id", nullable = false)
+    @ToString.Exclude
+    private SchedulerParticipant participant;
+}

--- a/src/main/java/dev/goral/rpgmanager/scheduler/entity/FinalDecision.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/entity/FinalDecision.java
@@ -1,0 +1,17 @@
+package dev.goral.rpgmanager.scheduler.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class FinalDecision {
+    private LocalDateTime start;
+    private LocalDateTime end;
+}

--- a/src/main/java/dev/goral/rpgmanager/scheduler/entity/Scheduler.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/entity/Scheduler.java
@@ -1,0 +1,59 @@
+package dev.goral.rpgmanager.scheduler.entity;
+
+import dev.goral.rpgmanager.game.Game;
+import dev.goral.rpgmanager.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Entity
+@Table(name = "schedulers")
+public class Scheduler {
+
+    @Id
+    @SequenceGenerator(
+            name = "scheduler_sequence",
+            sequenceName = "scheduler_sequence",
+            allocationSize = 1
+    )
+    @GeneratedValue(
+            strategy = GenerationType.SEQUENCE,
+            generator = "scheduler_sequence"
+    )
+    private Long id;
+
+    private String title;
+    private LocalDateTime deadline;
+    private Integer minimumSessionDurationMinutes;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id", nullable = false)
+    @ToString.Exclude
+    private Game game;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creator_id", nullable = false)
+    @ToString.Exclude
+    private User creator;
+
+    @OneToMany(mappedBy = "scheduler", cascade = CascadeType.ALL, orphanRemoval = true)
+    @ToString.Exclude
+    private List<SchedulerDateRange> dateRanges = new ArrayList<>();
+
+    @OneToMany(mappedBy = "scheduler", cascade = CascadeType.ALL, orphanRemoval = true)
+    @ToString.Exclude
+    private List<SchedulerParticipant> participants = new ArrayList<>();
+
+    @Embedded
+    private FinalDecision finalDecision;
+
+    private String googleCalendarLink;
+}
+

--- a/src/main/java/dev/goral/rpgmanager/scheduler/entity/Scheduler.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/entity/Scheduler.java
@@ -1,6 +1,7 @@
 package dev.goral.rpgmanager.scheduler.entity;
 
 import dev.goral.rpgmanager.game.Game;
+import dev.goral.rpgmanager.scheduler.enums.SchedulerStatus;
 import dev.goral.rpgmanager.user.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -50,6 +51,9 @@ public class Scheduler {
     @OneToMany(mappedBy = "scheduler", cascade = CascadeType.ALL, orphanRemoval = true)
     @ToString.Exclude
     private List<SchedulerParticipant> participants = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    private SchedulerStatus status = SchedulerStatus.AWAITING_AVAILABILITY;
 
     @Embedded
     private FinalDecision finalDecision;

--- a/src/main/java/dev/goral/rpgmanager/scheduler/entity/Scheduler.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/entity/Scheduler.java
@@ -53,6 +53,11 @@ public class Scheduler {
     @ToString.Exclude
     private List<SchedulerParticipant> participants = new ArrayList<>();
 
+    @ElementCollection
+    @CollectionTable(name = "scheduler_time_ranges", joinColumns = @JoinColumn(name = "scheduler_id"))
+    private List<TimeRange> timeRanges = new ArrayList<>();
+
+
     @Enumerated(EnumType.STRING)
     private SchedulerStatus status = SchedulerStatus.AWAITING_AVAILABILITY;
 

--- a/src/main/java/dev/goral/rpgmanager/scheduler/entity/Scheduler.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/entity/Scheduler.java
@@ -61,5 +61,9 @@ public class Scheduler {
 
     @Nullable
     private String googleCalendarLink;
+
+    @Column(nullable = false)
+    private boolean emailsSent = false;
+
 }
 

--- a/src/main/java/dev/goral/rpgmanager/scheduler/entity/Scheduler.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/entity/Scheduler.java
@@ -3,6 +3,7 @@ package dev.goral.rpgmanager.scheduler.entity;
 import dev.goral.rpgmanager.game.Game;
 import dev.goral.rpgmanager.scheduler.enums.SchedulerStatus;
 import dev.goral.rpgmanager.user.User;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -58,6 +59,7 @@ public class Scheduler {
     @Embedded
     private FinalDecision finalDecision;
 
+    @Nullable
     private String googleCalendarLink;
 }
 

--- a/src/main/java/dev/goral/rpgmanager/scheduler/entity/SchedulerDateRange.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/entity/SchedulerDateRange.java
@@ -1,0 +1,40 @@
+package dev.goral.rpgmanager.scheduler.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "scheduler_date_ranges")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class SchedulerDateRange {
+
+    @Id
+    @SequenceGenerator(
+            name = "scheduler_date_range_seq",
+            sequenceName = "scheduler_date_range_seq",
+            allocationSize = 1
+    )
+    @GeneratedValue(
+            strategy = GenerationType.SEQUENCE,
+            generator = "scheduler_date_range_seq"
+    )
+    private Long id;
+
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    private LocalTime startTime; // np. 17:00
+    private LocalTime endTime;   // np. 22:00
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "scheduler_id", nullable = false)
+    @ToString.Exclude
+    private Scheduler scheduler;
+}

--- a/src/main/java/dev/goral/rpgmanager/scheduler/entity/SchedulerDateRange.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/entity/SchedulerDateRange.java
@@ -30,9 +30,6 @@ public class SchedulerDateRange {
     private LocalDate startDate;
     private LocalDate endDate;
 
-    private LocalTime startTime; // np. 17:00
-    private LocalTime endTime;   // np. 22:00
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "scheduler_id", nullable = false)
     @ToString.Exclude

--- a/src/main/java/dev/goral/rpgmanager/scheduler/entity/SchedulerParticipant.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/entity/SchedulerParticipant.java
@@ -1,0 +1,46 @@
+package dev.goral.rpgmanager.scheduler.entity;
+
+import dev.goral.rpgmanager.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "scheduler_participants")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class SchedulerParticipant {
+
+    @Id
+    @SequenceGenerator(
+            name = "scheduler_participant_seq",
+            sequenceName = "scheduler_participant_seq",
+            allocationSize = 1
+    )
+    @GeneratedValue(
+            strategy = GenerationType.SEQUENCE,
+            generator = "scheduler_participant_seq"
+    )
+    private Long id;
+
+    private boolean notifiedByEmail;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "scheduler_id", nullable = false)
+    @ToString.Exclude
+    private Scheduler scheduler;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "player_id", nullable = false)
+    @ToString.Exclude
+    private User player;
+
+    @OneToMany(mappedBy = "participant", cascade = CascadeType.ALL, orphanRemoval = true)
+    @ToString.Exclude
+    private List<AvailabilitySlot> availabilitySlots = new ArrayList<>();
+}

--- a/src/main/java/dev/goral/rpgmanager/scheduler/entity/TimeRange.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/entity/TimeRange.java
@@ -1,0 +1,16 @@
+package dev.goral.rpgmanager.scheduler.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.time.LocalTime;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeRange {
+    private LocalTime startTime;
+    private LocalTime endTime;
+}

--- a/src/main/java/dev/goral/rpgmanager/scheduler/enums/AvailabilityType.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/enums/AvailabilityType.java
@@ -1,0 +1,7 @@
+package dev.goral.rpgmanager.scheduler.enums;
+
+public enum AvailabilityType {
+    YES,
+    MAYBE,
+    NO
+}

--- a/src/main/java/dev/goral/rpgmanager/scheduler/enums/SchedulerStatus.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/enums/SchedulerStatus.java
@@ -1,0 +1,7 @@
+package dev.goral.rpgmanager.scheduler.enums;
+
+public enum SchedulerStatus {
+    AWAITING_AVAILABILITY,
+    READY_TO_DECIDE,
+    FINALIZED
+}

--- a/src/main/java/dev/goral/rpgmanager/scheduler/repository/SchedulerRepository.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/repository/SchedulerRepository.java
@@ -4,7 +4,9 @@ import dev.goral.rpgmanager.scheduler.entity.Scheduler;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SchedulerRepository extends JpaRepository<Scheduler, Long> {
-
+    List<Scheduler> findByGameId(Long gameId);
 }

--- a/src/main/java/dev/goral/rpgmanager/scheduler/repository/SchedulerRepository.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/repository/SchedulerRepository.java
@@ -1,0 +1,10 @@
+package dev.goral.rpgmanager.scheduler.repository;
+
+import dev.goral.rpgmanager.scheduler.entity.Scheduler;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SchedulerRepository extends JpaRepository<Scheduler, Long> {
+
+}

--- a/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerResponseMapper.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerResponseMapper.java
@@ -29,6 +29,13 @@ public class SchedulerResponseMapper {
                                         p.isNotifiedByEmail()
                                 )).toList()
                 )
+                .status(s.getStatus())
+                .missingAvailabilitiesCount(
+                        (int) s.getParticipants().stream()
+                                .filter(p -> p.getAvailabilitySlots() == null || p.getAvailabilitySlots().isEmpty())
+                                .count()
+                )
+
                 .finalDecision(
                         s.getFinalDecision() == null ? null :
                                 new SchedulerResponse.FinalDecisionDto(

--- a/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerResponseMapper.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerResponseMapper.java
@@ -1,0 +1,42 @@
+package dev.goral.rpgmanager.scheduler.service;
+
+import dev.goral.rpgmanager.scheduler.dto.response.SchedulerResponse;
+import dev.goral.rpgmanager.scheduler.entity.Scheduler;
+
+public class SchedulerResponseMapper {
+
+    public static SchedulerResponse mapToDto(Scheduler s) {
+        return SchedulerResponse.builder()
+                .id(s.getId())
+                .title(s.getTitle())
+                .deadline(s.getDeadline())
+                .minimumSessionDurationMinutes(s.getMinimumSessionDurationMinutes())
+                .gameId(s.getGame().getId())
+                .creatorId(s.getCreator().getId())
+                .googleCalendarLink(s.getGoogleCalendarLink())
+                .dateRanges(
+                        s.getDateRanges().stream()
+                                .map(d -> new SchedulerResponse.DateRangeDto(
+                                        d.getStartDate(), d.getEndDate(),
+                                        d.getStartTime(), d.getEndTime()))
+                                .toList()
+                )
+                .participants(
+                        s.getParticipants().stream()
+                                .map(p -> new SchedulerResponse.ParticipantDto(
+                                        p.getId(),
+                                        p.getPlayer().getId(),
+                                        p.isNotifiedByEmail()
+                                )).toList()
+                )
+                .finalDecision(
+                        s.getFinalDecision() == null ? null :
+                                new SchedulerResponse.FinalDecisionDto(
+                                        s.getFinalDecision().getStart(),
+                                        s.getFinalDecision().getEnd()
+                                )
+                )
+                .build();
+    }
+}
+

--- a/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerResponseMapper.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerResponseMapper.java
@@ -3,6 +3,8 @@ package dev.goral.rpgmanager.scheduler.service;
 import dev.goral.rpgmanager.scheduler.dto.response.SchedulerResponse;
 import dev.goral.rpgmanager.scheduler.entity.Scheduler;
 
+import java.util.stream.Collectors;
+
 public class SchedulerResponseMapper {
 
     public static SchedulerResponse mapToDto(Scheduler s) {
@@ -13,22 +15,34 @@ public class SchedulerResponseMapper {
                 .minimumSessionDurationMinutes(s.getMinimumSessionDurationMinutes())
                 .gameId(s.getGame().getId())
                 .creatorId(s.getCreator().getId())
+
                 .dateRanges(
                         s.getDateRanges().stream()
                                 .map(d -> new SchedulerResponse.DateRangeDto(
-                                        d.getStartDate(), d.getEndDate(),
-                                        d.getStartTime(), d.getEndTime()))
-                                .toList()
+                                        d.getStartDate(),
+                                        d.getEndDate()
+                                )).collect(Collectors.toList())
                 )
+
+                .timeRanges(
+                        s.getTimeRanges().stream()
+                                .map(t -> new SchedulerResponse.TimeRangeDto(
+                                        t.getStartTime(),
+                                        t.getEndTime()
+                                )).collect(Collectors.toList())
+                )
+
                 .participants(
                         s.getParticipants().stream()
                                 .map(p -> new SchedulerResponse.ParticipantDto(
                                         p.getId(),
                                         p.getPlayer().getId(),
                                         p.isNotifiedByEmail()
-                                )).toList()
+                                )).collect(Collectors.toList())
                 )
+
                 .status(s.getStatus())
+
                 .missingAvailabilitiesCount(
                         (int) s.getParticipants().stream()
                                 .filter(p -> p.getAvailabilitySlots() == null || p.getAvailabilitySlots().isEmpty())
@@ -42,9 +56,10 @@ public class SchedulerResponseMapper {
                                         s.getFinalDecision().getEnd()
                                 )
                 )
-                .googleCalendarLink( s.getGoogleCalendarLink())
+
+                .googleCalendarLink(s.getGoogleCalendarLink())
                 .emailsSent(s.isEmailsSent())
+
                 .build();
     }
 }
-

--- a/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerResponseMapper.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerResponseMapper.java
@@ -13,7 +13,6 @@ public class SchedulerResponseMapper {
                 .minimumSessionDurationMinutes(s.getMinimumSessionDurationMinutes())
                 .gameId(s.getGame().getId())
                 .creatorId(s.getCreator().getId())
-                .googleCalendarLink(s.getGoogleCalendarLink())
                 .dateRanges(
                         s.getDateRanges().stream()
                                 .map(d -> new SchedulerResponse.DateRangeDto(

--- a/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerResponseMapper.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerResponseMapper.java
@@ -44,6 +44,7 @@ public class SchedulerResponseMapper {
                                 )
                 )
                 .googleCalendarLink( s.getGoogleCalendarLink())
+                .emailsSent(s.isEmailsSent())
                 .build();
     }
 }

--- a/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerResponseMapper.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerResponseMapper.java
@@ -43,6 +43,7 @@ public class SchedulerResponseMapper {
                                         s.getFinalDecision().getEnd()
                                 )
                 )
+                .googleCalendarLink( s.getGoogleCalendarLink())
                 .build();
     }
 }

--- a/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerService.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerService.java
@@ -1,0 +1,148 @@
+package dev.goral.rpgmanager.scheduler.service;
+
+import dev.goral.rpgmanager.game.GameRepository;
+import dev.goral.rpgmanager.game.gameUsers.GameUsersRepository;
+import dev.goral.rpgmanager.scheduler.dto.request.CreateSchedulerRequest;
+import dev.goral.rpgmanager.scheduler.dto.response.SchedulerResponse;
+import dev.goral.rpgmanager.scheduler.entity.*;
+import dev.goral.rpgmanager.scheduler.repository.SchedulerRepository;
+import dev.goral.rpgmanager.user.User;
+import dev.goral.rpgmanager.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.Principal;
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SchedulerService {
+
+    private final SchedulerRepository schedulerRepository;
+    private final GameRepository gameRepository;
+    private final GameUsersRepository gameUsersRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public SchedulerResponse createScheduler(CreateSchedulerRequest request, @AuthenticationPrincipal Principal principal) {
+
+        User creator = userRepository.findByUsername(principal.getName())
+                .orElseThrow(() -> new IllegalArgumentException("Nie znaleziono użytkownika: " + principal.getName()));
+
+        // Sprawdź, czy użytkownik jest twórcą gry
+        if (!creator.getId().equals(request.getCreatorId())) {
+            throw new IllegalArgumentException("Użytkownik nie jest twórcą gry");
+        }
+
+        // Sprawdź, czy użytkownik jest uczestnikiem gry
+        if (!gameUsersRepository.existsByGameIdAndUserId(request.getGameId(), creator.getId())) {
+            throw new IllegalArgumentException("Użytkownik nie jest uczestnikiem gry");
+        }
+
+        // Walidacja
+        validateRequest(request);
+
+        // Utwórz encję Scheduler
+        Scheduler scheduler = new Scheduler();
+        scheduler.setTitle(request.getTitle());
+        scheduler.setDeadline(request.getDeadline());
+        scheduler.setMinimumSessionDurationMinutes(request.getMinimumSessionDurationMinutes());
+
+        // Pobierz Game i Creator
+        scheduler.setGame(gameRepository.findById(request.getGameId())
+                .orElseThrow(() -> new IllegalArgumentException("Nie znaleziono gry o id: " + request.getGameId())));
+
+        scheduler.setCreator(userRepository.findById(request.getCreatorId())
+                .orElseThrow(() -> new IllegalArgumentException("Nie znaleziono twórcy gry: " + request.getCreatorId())));
+
+        // Zakresy dat
+        scheduler.setDateRanges(
+                request.getDateRanges().stream()
+                        .map(dto -> new SchedulerDateRange(
+                                null,
+                                dto.getStartDate(),
+                                dto.getEndDate(),
+                                dto.getStartTime(),
+                                dto.getEndTime(),
+                                scheduler
+                        ))
+                        .collect(Collectors.toList())
+        );
+
+        // Uczestnicy
+        scheduler.setParticipants(
+                request.getParticipantIds().stream()
+                        .map(pid -> {
+                            SchedulerParticipant participant = new SchedulerParticipant();
+                            participant.setScheduler(scheduler);
+                            participant.setPlayer(userRepository.findById(pid)
+                                    .orElseThrow(() -> new IllegalArgumentException("Nie znaleziono gracza: " + pid)));
+                            participant.setNotifiedByEmail(true);
+                            return participant;
+                        })
+                        .collect(Collectors.toList())
+        );
+
+        // Zapisz scheduler
+        Scheduler saved = schedulerRepository.save(scheduler);
+
+        // Mapowanie do DTO
+        return SchedulerResponseMapper.mapToDto(saved);
+    }
+
+    private void validateRequest(CreateSchedulerRequest request) {
+        if (request.getTitle() == null || request.getTitle().isBlank()) {
+            throw new IllegalArgumentException("Tytuł nie może być pusty");
+        }
+
+        if (request.getDeadline() == null || request.getDeadline().isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException("Termin wypełnienia dostępności nie może być w przeszłości");
+        }
+
+        if (request.getMinimumSessionDurationMinutes() == null || request.getMinimumSessionDurationMinutes() <= 0) {
+            throw new IllegalArgumentException("Minimalny czas sesji musi być większy od 0");
+        }
+
+        if (request.getDateRanges() == null || request.getDateRanges().isEmpty()) {
+            throw new IllegalArgumentException("Musi być podany przynajmniej jeden zakres dat");
+        }
+
+        for (CreateSchedulerRequest.DateRangeDto range : request.getDateRanges()) {
+            if (range.getStartDate() == null || range.getEndDate() == null ||
+                    range.getStartTime() == null || range.getEndTime() == null) {
+                throw new IllegalArgumentException("Zakresy dat i godzin nie mogą być puste");
+            }
+
+            if (range.getStartDate().isAfter(range.getEndDate())) {
+                throw new IllegalArgumentException("Data początkowa nie może być po dacie końcowej");
+            }
+
+            if (range.getStartDate().isEqual(range.getEndDate()) && range.getStartTime().isAfter(range.getEndTime())) {
+                throw new IllegalArgumentException("Dla tej samej daty, czas początkowy nie może być po czasie końcowym");
+            }
+        }
+
+        if (request.getParticipantIds() == null || request.getParticipantIds().isEmpty()) {
+            throw new IllegalArgumentException("Musi być przynajmniej jeden uczestnik");
+        }
+
+        long uniqueCount = request.getParticipantIds().stream().distinct().count();
+        if (uniqueCount != request.getParticipantIds().size()) {
+            throw new IllegalArgumentException("Na liście uczestników znajdują się duplikaty");
+        }
+
+        if (!request.getParticipantIds().contains(request.getCreatorId())) {
+            throw new IllegalArgumentException("Twórca schedulera powinien być również jego uczestnikiem");
+        }
+
+        for (Long participantId : request.getParticipantIds()) {
+            if (!this.gameUsersRepository.existsByGameIdAndUserId(request.getGameId(), participantId)) {
+                throw new IllegalArgumentException("Uczestnik o id " + participantId + " nie jest uczestnikiem gry");
+            }
+        }
+    }
+
+}

--- a/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerService.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerService.java
@@ -2,6 +2,7 @@ package dev.goral.rpgmanager.scheduler.service;
 
 import dev.goral.rpgmanager.email.EmailService;
 import dev.goral.rpgmanager.game.GameRepository;
+import dev.goral.rpgmanager.game.GameStatus;
 import dev.goral.rpgmanager.game.gameUsers.GameUsersRepository;
 import dev.goral.rpgmanager.scheduler.dto.common.TimeRangeDto;
 import dev.goral.rpgmanager.scheduler.dto.request.CreateSchedulerRequest;
@@ -76,6 +77,13 @@ public class SchedulerService {
                 .orElseThrow(() -> new IllegalStateException("Nie znaleziono gry o id: " + request.getGameId()))
                 .getGameMaster().getId().equals(creator.getId())) {
             throw new IllegalStateException("Tylko GameMaster może stworzyć harmonogram");
+        }
+
+        // Sprawdź, czy gra ma status ACTIVE
+        if (gameRepository.findById(request.getGameId())
+                .orElseThrow(() -> new IllegalStateException("Nie znaleziono gry o id: " + request.getGameId()))
+                .getStatus() != GameStatus.ACTIVE) {
+            throw new IllegalStateException("Gra musi być aktywna, aby stworzyć dla niej harmonogram.");
         }
 
         // Walidacja

--- a/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerService.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerService.java
@@ -628,6 +628,7 @@ public class SchedulerService {
                 double weight = switch (slot.getAvailabilityType()) {
                     case AvailabilityType.YES -> 1.0;
                     case AvailabilityType.MAYBE -> 0.5;
+                    case AvailabilityType.NO -> -1.0;
                     default -> 0.0;
                 };
                 if (weight > 0) {

--- a/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerService.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerService.java
@@ -127,6 +127,8 @@ public class SchedulerService {
         // Zapisz scheduler
         Scheduler saved = schedulerRepository.save(scheduler);
 
+        emailService.sendSchedulerCreatedNotification(saved);
+
         // Mapowanie do DTO
         return SchedulerResponseMapper.mapToDto(saved);
     }

--- a/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerService.java
+++ b/src/main/java/dev/goral/rpgmanager/scheduler/service/SchedulerService.java
@@ -20,9 +20,14 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -364,6 +369,23 @@ public class SchedulerService {
 
         scheduler.setFinalDecision(decision);
         scheduler.setStatus(SchedulerStatus.FINALIZED);
+
+        // Link do Google Calendar
+        String title = URLEncoder.encode(scheduler.getTitle(), StandardCharsets.UTF_8);
+        String details = URLEncoder.encode("Spotkanie RPG przez aplikację RPG Handy Helper", StandardCharsets.UTF_8);
+
+        String startUtc = start.atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC)
+                .format(DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'"));
+
+        String endUtc = end.atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC)
+                .format(DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'"));
+
+        String calendarLink = String.format(
+                "https://calendar.google.com/calendar/render?action=TEMPLATE&text=%s&dates=%s/%s&details=%s",
+                title, startUtc, endUtc, details
+        );
+
+        scheduler.setGoogleCalendarLink(calendarLink);
 
         Scheduler saved = schedulerRepository.save(scheduler);
         return SchedulerResponseMapper.mapToDto(saved);


### PR DESCRIPTION
## Dodałem pełną funkcjonalność schedulerów sesji RPG

GameMaster może teraz tworzyć terminarze do wspólnego ustalania dogodnego terminu sesji z graczami.

### Zakres funkcjonalności:
- Możliwość utworzenia scheduler'a dla konkretnej gry.
- Definiowanie tytułu, deadline'u na wypełnienie dostępności, minimalnego czasu sesji oraz nieregularnych zakresów dat i godzin.
- Dodanie listy uczestników (graczy).
- Możliwość edycji scheduler'a do momentu wyboru terminu.
- Usuwanie scheduler'a przez twórcę.
- Składanie dostępności przez graczy z poziomem: `YES`, `MAYBE`, `NO`.
- Możliwość edytowania swojej dostępności.
- Wyszukiwanie wspólnych okien czasowych:
  - Zbiera przecięcia dostępności graczy,
  - Agreguje preferencje i wagi (`YES = 1`, `MAYBE = 0.5`),
  - Filtrowanie po minimalnej długości sesji.
- Możliwość ręcznego wybrania finalnego terminu przez GM.
- Generowanie linku do Google Kalendarza na podstawie finalnego terminu.
- Wysyłanie powiadomień e-mail:
  - Po utworzeniu scheduler'a do wszystkich uczestników,
  - Po wybraniu terminu – z potwierdzeniem terminu i linkiem do kalendarza.
- Ochrona przed wielokrotną wysyłką wiadomości (`emailsSent`).

### Aby przetestować:
1. Zalogować się jako GameMaster.
2. Stworzyć grę.
3. Utworzyć scheduler – musisz być także uczestnikiem!
4. Dołączyć przynajmniej jednego gracza do scheduler'a.
5. Jako gracz wypełnić dostępność przez `/submitAvailability`.
6. Wyświetlić propozycje przez `/suggestedSlots/{schedulerId}`.
7. Wybrać termin przez `/setFinalDecision`.
8. Wysłać e-maile przez `/sendFinalDecisionMails`.

### Wspierane endpointy:
> Jest ich łącznie 11 o ile dobrze pamiętam, wszystkie są w jet clientcie
- Tworzenie, edycja, usuwanie scheduler'a
- Dodawanie i edycja dostępności graczy
- Sugestie terminów
- Pobranie dostępności aktualnego użytkownika
- Wysyłanie powiadomień e-mail

Do repozytorium dołączona została również dokumentacja techniczna `SchedulerController.md`.