### PR TITLE
Naprawa zmiany nicku po logowaniu discordem

### DIFF
--- a/src/main/java/dev/goral/rpgmanager/security/CustomOAuth2UserService.java
+++ b/src/main/java/dev/goral/rpgmanager/security/CustomOAuth2UserService.java
@@ -40,16 +40,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         User user;
 
         if (existingUserByOAuthId.isPresent()) {
-            // Użytkownik już logował się przez Discord - aktualizujemy jego dane (np. nazwę użytkownika)
             user = existingUserByOAuthId.get();
-
-            if (!user.getUsername().equals(username)) {
-                if (userRepository.findByUsername(username).isPresent()) {
-                    username = generateUniqueUsername(username);
-                }
-                user.setUsername(username);
-                userRepository.save(user);
-            }
         } else if (existingUserByEmail.isPresent()) {
             // Użytkownik ma już konto w bazie przez e-mail, ale loguje się pierwszy raz przez Discord -> Powiązanie konta!
             user = existingUserByEmail.get();


### PR DESCRIPTION
Naprawiłem błąd, w którym po zalogowaniu się discordem na istniejące już konto, nadpisywał się nick w wypadku, gdy był inny niż discordowy.

Aby to przetestować:
1. Tworzymy konto poprzez Discord
2. Na moim profilu zmieniamy nick
3. Wylogowujemy się
4. Logujemy się discordem
5. Po przejściu na Mój Profil powinniśmy widzieć już stary nick, sprzed logowania