### PR TITLE
Service/controller dla cp red critical injuries

### DIFF
--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -758,6 +758,64 @@
                                   </option>
                                   <option name="sortWeight" value="5000000" />
                                 </folderState>
+                                <folderState>
+                                  <option name="id" value="0cc78d9c-5f51-4b86-a99b-1a3d87fe7066" />
+                                  <option name="name" value="CriticalInjuries" />
+                                  <option name="requests">
+                                    <list>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  rollValue: 3,&#10;  injuryPlace: &quot;HEAD&quot;,&#10;  name: &quot;Critical Hit&quot;,&#10;  effects: &quot;Critical damage&quot;,&#10;  patching: &quot;None&quot;,&#10;  treating: &quot;None&quot;&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="id" value="c9a64323-3a0d-4999-be22-c6caadd84df7" />
+                                        <option name="method" value="POST" />
+                                        <option name="name" value="Dodaj obrażenia krytyczne" />
+                                        <option name="sortWeight" value="1000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/criticalInjuries/add" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  rollValue: 2,&#10;  injuryPlace: &quot;HEAD&quot;,&#10;  name: &quot;Critical Hit 2.0&quot;,&#10;  effects: &quot;Critical damage&quot;,&#10;  patching: &quot;yes&quot;,&#10;  treating: &quot;None&quot;&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="id" value="53375029-61a3-4885-bca7-3aacb4f0cf4e" />
+                                        <option name="method" value="PUT" />
+                                        <option name="name" value="Modyfikuj obrażenia krytyczne" />
+                                        <option name="sortWeight" value="2000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/criticalInjuries/update/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca listę wszystkich obrażeń krytycznych" />
+                                        <option name="id" value="ffdb58df-53c8-4f63-af80-82b905ebc645" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobierz wszystkie obrażenia krytyczne" />
+                                        <option name="sortWeight" value="3000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/criticalInjuries/all" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="id" value="4dc22482-4b8a-459b-9afc-4ca3779ea531" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobierz konkretne obrażenia krytyczne po id" />
+                                        <option name="sortWeight" value="4000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/criticalInjuries/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca listę obiektów" />
+                                        <option name="id" value="825da758-04bb-47fe-91e9-6455b070d9af" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobierz wszystkie obrażenia krytyczne dla Admina" />
+                                        <option name="sortWeight" value="5000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/criticalInjuries/all" />
+                                      </requestState>
+                                    </list>
+                                  </option>
+                                  <option name="sortWeight" value="6000000" />
+                                </folderState>
                               </list>
                             </option>
                             <option name="id" value="22a51bac-54eb-48dd-a9c8-e0df68e57dae" />

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/criticalInjuries/CpRedCriticalInjuriesController.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/criticalInjuries/CpRedCriticalInjuriesController.java
@@ -12,33 +12,29 @@ import java.util.Map;
 public class CpRedCriticalInjuriesController {
     private CpRedCriticalInjuriesService cpRedCriticalInjuriesService;
 
-//    // ============ User methods ============
-//    // Pobierz wszystkie obrażenia krytyczne
-//    @GetMapping(path = "/rpgSystems/cpRed/criticalInjuries/all")
-//    public Map<String, Object> getAllCriticalInjuries() { // List<CpRedCriticalInjuriesDTO>
-//        return cpRedCriticalInjuriesService.getAllCriticalInjuries();
-//    }
-//    // Pobierz obrażenia krytyczne po id
-//    @GetMapping(path = "/rpgSystems/cpRed/criticalInjuries/{injuryId}")
-//    public Map<String, Object> getCriticalInjuryById(@PathVariable("injuryId") Long injuryId) { // CpRedCriticalInjuriesDTO
-//        return cpRedCriticalInjuriesService.getCriticalInjuryById(injuryId);
-//    }
-//
-//    // ============ Admin methods ============
-//    // Pobierz wszystkie obrażenia krytyczne dla admina
-//    @GetMapping(path = "/admin/rpgSystems/cpRed/criticalInjuries/all")
-//    public Map<String, Object> getAllCriticalInjuriesForAdmin() { // List<CpRedCriticalInjuries>
-//        return cpRedCriticalInjuriesService.getAllCriticalInjuriesForAdmin();
-//    }
-//    // Dodać obrażenia krytyczne
-//    @PostMapping(path = "/admin/rpgSystems/cpRed/criticalInjuries/add")
-//    public Map<String, Object> addCriticalInjury(@RequestBody CpRedCriticalInjuries cpRedCriticalInjuries) {
-//        return cpRedCriticalInjuriesService.addCriticalInjury(cpRedCriticalInjuries);
-//    }
-//    // Modyfikować obrażenia krytyczne
-//    @PutMapping(path = "/admin/rpgSystems/cpRed/criticalInjuries/update/{injuryId}")
-//    public Map<String, Object> updateCriticalInjury(@PathVariable("injuryId") Long injuryId,
-//                                                    @RequestBody CpRedCriticalInjuries cpRedCriticalInjuries) {
-//        return cpRedCriticalInjuriesService.updateCriticalInjury(injuryId, cpRedCriticalInjuries);
-//    }
+    @GetMapping(path = "/rpgSystems/cpRed/criticalInjuries/all")
+    public Map<String, Object> getAllCriticalInjuries() { // List<CpRedCriticalInjuriesDTO>
+        return cpRedCriticalInjuriesService.getAllCriticalInjuries();
+    }
+
+    @GetMapping(path = "/rpgSystems/cpRed/criticalInjuries/{injuryId}")
+    public Map<String, Object> getCriticalInjuryById(@PathVariable("injuryId") Long injuryId) { // CpRedCriticalInjuriesDTO
+        return cpRedCriticalInjuriesService.getCriticalInjuryById(injuryId);
+    }
+
+    @GetMapping(path = "/admin/rpgSystems/cpRed/criticalInjuries/all")
+    public Map<String, Object> getAllCriticalInjuriesForAdmin() { // List<CpRedCriticalInjuries>
+        return cpRedCriticalInjuriesService.getAllCriticalInjuriesForAdmin();
+    }
+
+    @PostMapping(path = "/admin/rpgSystems/cpRed/criticalInjuries/add")
+    public Map<String, Object> addCriticalInjury(@RequestBody CpRedCriticalInjuries cpRedCriticalInjuries) {
+        return cpRedCriticalInjuriesService.addCriticalInjury(cpRedCriticalInjuries);
+    }
+
+    @PutMapping(path = "/admin/rpgSystems/cpRed/criticalInjuries/update/{injuryId}")
+    public Map<String, Object> updateCriticalInjury(@PathVariable("injuryId") Long injuryId,
+                                                    @RequestBody CpRedCriticalInjuries cpRedCriticalInjuries) {
+        return cpRedCriticalInjuriesService.updateCriticalInjury(injuryId, cpRedCriticalInjuries);
+    }
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/criticalInjuries/CpRedCriticalInjuriesRepository.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/criticalInjuries/CpRedCriticalInjuriesRepository.java
@@ -5,4 +5,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CpRedCriticalInjuriesRepository extends JpaRepository<CpRedCriticalInjuries, Long> {
+    Boolean existsByName(String name);
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/criticalInjuries/CpRedCriticalInjuriesService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/criticalInjuries/CpRedCriticalInjuriesService.java
@@ -1,5 +1,6 @@
 package dev.goral.rpgmanager.rpgSystems.cpRed.manual.criticalInjuries;
 
+import dev.goral.rpgmanager.security.CustomReturnables;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,10 +12,22 @@ import java.util.Map;
 public class CpRedCriticalInjuriesService {
     private final CpRedCriticalInjuriesRepository cpRedCriticalInjuriesRepository;
 
-//    // Pobierz wszystkie obrażenia krytyczne
-//    public Map<String, Object> getAllCriticalInjuries() {
-//
-//    }
+    // Pobierz wszystkie obrażenia krytyczne
+    public Map<String, Object> getAllCriticalInjuries() {
+        List<CpRedCriticalInjuriesDTO> cpRedCriticalInjuriesList = cpRedCriticalInjuriesRepository.findAll().stream().
+                map(cpRedCriticalInjuries -> new CpRedCriticalInjuriesDTO(
+                        cpRedCriticalInjuries.getRollValue(),
+                        cpRedCriticalInjuries.getInjuryPlace().toString(),
+                        cpRedCriticalInjuries.getName(),
+                        cpRedCriticalInjuries.getEffects(),
+                        cpRedCriticalInjuries.getPatching(),
+                        cpRedCriticalInjuries.getTreating()
+                )).toList();
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano wszystkie rodzaje obrażeń krytycznych.");
+        response.put("criticalInjuries", cpRedCriticalInjuriesList);
+        return response;
+
+    }
 //
 //    // Pobierz obrażenia krytyczne po id
 //    public Map<String, Object> getCriticalInjuryById(Long criticalInjuryId) {

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/criticalInjuries/CpRedCriticalInjuriesService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/criticalInjuries/CpRedCriticalInjuriesService.java
@@ -1,5 +1,6 @@
 package dev.goral.rpgmanager.rpgSystems.cpRed.manual.criticalInjuries;
 
+import dev.goral.rpgmanager.rpgSystems.cpRed.manual.cyberwares.CpRedCyberwares;
 import dev.goral.rpgmanager.security.CustomReturnables;
 import dev.goral.rpgmanager.security.exceptions.ResourceNotFoundException;
 import dev.goral.rpgmanager.user.User;
@@ -119,8 +120,70 @@ public class CpRedCriticalInjuriesService {
         return CustomReturnables.getOkResponseMap("Obrażenia krytyczne zostały dodane.");
     }
 
-//    public Map<String, Object> updateCriticalInjury(Long criticalInjuryId, CpRedCriticalInjuries cpRedCriticalInjuries) {
-//
-//    }
+    public Map<String, Object> updateCriticalInjury(Long criticalInjuryId, CpRedCriticalInjuries cpRedCriticalInjuries) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
 
+        if (!currentUser.getRole().equals(UserRole.ROLE_ADMIN)) {
+            throw new IllegalStateException("Nie masz uprawnień do dodawania obrażeń krytycznych.");
+        }
+        CpRedCriticalInjuries injuriesToUpdate = cpRedCriticalInjuriesRepository.findById(criticalInjuryId)
+                .orElseThrow(() -> new ResourceNotFoundException("Obrażenia krytyczne o id " + criticalInjuryId + " nie istnieją"));
+
+        if(cpRedCriticalInjuries.getRollValue() <= 0) {
+            throw new IllegalStateException("Rzut nie może być ujemny lub równy zero.");
+        }
+        injuriesToUpdate.setRollValue(cpRedCriticalInjuries.getRollValue());
+
+        if(cpRedCriticalInjuries.getInjuryPlace() != null) {
+            injuriesToUpdate.setInjuryPlace(cpRedCriticalInjuries.getInjuryPlace());
+        }
+
+        if (cpRedCriticalInjuries.getName() != null) {
+            if (cpRedCriticalInjuriesRepository.existsByName(cpRedCriticalInjuries.getName())) {
+                throw new IllegalStateException("Obrażenia krytyczne o tej nazwie już istnieją.");
+            }
+            if (cpRedCriticalInjuries.getName().isEmpty() || cpRedCriticalInjuries.getName().trim().isEmpty()) {
+                throw new IllegalStateException("Nazwa obrażeń krytycznych nie może być pusta.");
+            }
+            if (cpRedCriticalInjuries.getName().length() > 255) {
+                throw new IllegalStateException("Nazwa obrażeń krytycznych nie może być dłuższa niż 255 znaków.");
+            }
+            injuriesToUpdate.setName(cpRedCriticalInjuries.getName());
+        }
+
+        if (cpRedCriticalInjuries.getEffects() != null) {
+            if (cpRedCriticalInjuries.getEffects().isEmpty() || cpRedCriticalInjuries.getEffects().trim().isEmpty()) {
+                throw new IllegalStateException("Efekty obrażeń krytycznych nie mogą być puste.");
+            }
+            if (cpRedCriticalInjuries.getEffects().length() > 500) {
+                throw new IllegalStateException("Efekty obrażeń krytycznych nie mogą być dłuższe niż 500 znaków.");
+            }
+            injuriesToUpdate.setEffects(cpRedCriticalInjuries.getEffects());
+        }
+
+        if (cpRedCriticalInjuries.getPatching() != null) {
+            if (cpRedCriticalInjuries.getPatching().isEmpty() || cpRedCriticalInjuries.getPatching().trim().isEmpty()) {
+                throw new IllegalStateException("Łatanie obrażeń krytycznych nie moźe być puste.");
+            }
+            if (cpRedCriticalInjuries.getPatching().length() > 255) {
+                throw new IllegalStateException("Łatanie obrażeń krytycznych nie może być dłuższe niż 255 znaków.");
+            }
+            injuriesToUpdate.setPatching(cpRedCriticalInjuries.getPatching());
+        }
+
+        if (cpRedCriticalInjuries.getTreating() != null) {
+            if (cpRedCriticalInjuries.getTreating().isEmpty() || cpRedCriticalInjuries.getTreating().trim().isEmpty()) {
+                throw new IllegalStateException("Leczenie obrażeń krytycznych nie moźe być puste.");
+            }
+            if (cpRedCriticalInjuries.getTreating().length() > 255) {
+                throw new IllegalStateException("Leczenie obrażeń krytycznych nie może być dłuższe niż 255 znaków.");
+            }
+            injuriesToUpdate.setTreating(cpRedCriticalInjuries.getTreating());
+        }
+        cpRedCriticalInjuriesRepository.save(injuriesToUpdate);
+        return CustomReturnables.getOkResponseMap("Obrażenia krytyczne zostały zaktualizowane.");
+    }
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/criticalInjuries/CpRedCriticalInjuriesService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/criticalInjuries/CpRedCriticalInjuriesService.java
@@ -1,6 +1,4 @@
 package dev.goral.rpgmanager.rpgSystems.cpRed.manual.criticalInjuries;
-
-import dev.goral.rpgmanager.rpgSystems.cpRed.manual.cyberwares.CpRedCyberwares;
 import dev.goral.rpgmanager.security.CustomReturnables;
 import dev.goral.rpgmanager.security.exceptions.ResourceNotFoundException;
 import dev.goral.rpgmanager.user.User;
@@ -69,7 +67,7 @@ public class CpRedCriticalInjuriesService {
         if (!currentUser.getRole().equals(UserRole.ROLE_ADMIN)) {
             throw new IllegalStateException("Nie masz uprawnień do dodawania obrażeń krytycznych.");
         }
-        if(cpRedCriticalInjuries.getInjuryPlace().toString()==null ||
+        if(cpRedCriticalInjuries.getInjuryPlace()==null ||
                 cpRedCriticalInjuries.getName()==null ||
                 cpRedCriticalInjuries.getEffects()==null ||
                 cpRedCriticalInjuries.getPatching()==null ||
@@ -96,13 +94,13 @@ public class CpRedCriticalInjuriesService {
         }
 
         if (cpRedCriticalInjuries.getPatching().isEmpty() || cpRedCriticalInjuries.getPatching().trim().isEmpty()) {
-            throw new IllegalStateException("Łatanie obrażeń krytycznych nie moźe być puste.");
+            throw new IllegalStateException("Łatanie obrażeń krytycznych nie może być puste.");
         }
         if (cpRedCriticalInjuries.getPatching().length() > 255) {
             throw new IllegalStateException("Łatanie obrażeń krytycznych nie może być dłuższe niż 255 znaków.");
         }
         if (cpRedCriticalInjuries.getTreating().isEmpty() || cpRedCriticalInjuries.getTreating().trim().isEmpty()) {
-            throw new IllegalStateException("Leczenie obrażeń krytycznych nie moźe być puste.");
+            throw new IllegalStateException("Leczenie obrażeń krytycznych nie może być puste.");
         }
         if (cpRedCriticalInjuries.getTreating().length() > 255) {
             throw new IllegalStateException("Leczenie obrażeń krytycznych nie może być dłuższe niż 255 znaków.");

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/criticalInjuries/CpRedCriticalInjuriesService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/criticalInjuries/CpRedCriticalInjuriesService.java
@@ -46,10 +46,14 @@ public class CpRedCriticalInjuriesService {
 
     }
 
-//    // Pobierz wszystkie obrażenia krytyczne dla admina
-//    public Map<String, Object> getAllCriticalInjuriesForAdmin() {
-//
-//    }
+    // Pobierz wszystkie obrażenia krytyczne dla admina
+    public Map<String, Object> getAllCriticalInjuriesForAdmin() {
+        List<CpRedCriticalInjuries> allCriticalInjuries = cpRedCriticalInjuriesRepository.findAll();
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano wszystkie obrażenia krytyczne.");
+        response.put("criticalInjuries", allCriticalInjuries);
+        return response;
+
+    }
 //
 //    // Dodaj obrażenia krytyczne
 //    public Map<String, Object> addCriticalInjury(CpRedCriticalInjuries cpRedCriticalInjuries) {

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/criticalInjuries/CpRedCriticalInjuriesService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/criticalInjuries/CpRedCriticalInjuriesService.java
@@ -29,11 +29,23 @@ public class CpRedCriticalInjuriesService {
 
     }
 //
-//    // Pobierz obrażenia krytyczne po id
-//    public Map<String, Object> getCriticalInjuryById(Long criticalInjuryId) {
-//
-//    }
-//
+    // Pobierz obrażenia krytyczne po id
+    public Map<String, Object> getCriticalInjuryById(Long criticalInjuryId) {
+        CpRedCriticalInjuriesDTO criticalInjury = cpRedCriticalInjuriesRepository.findById(criticalInjuryId).map(
+                cpRedCriticalInjuries -> new CpRedCriticalInjuriesDTO(
+                        cpRedCriticalInjuries.getRollValue(),
+                        cpRedCriticalInjuries.getInjuryPlace().toString(),
+                        cpRedCriticalInjuries.getName(),
+                        cpRedCriticalInjuries.getEffects(),
+                        cpRedCriticalInjuries.getPatching(),
+                        cpRedCriticalInjuries.getTreating()
+                )).orElseThrow(() -> new RuntimeException("Obrażenia krytyczne o id " + criticalInjuryId + " nie istnieją"));
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano obrażenia krytyczne o id " + criticalInjuryId);
+        response.put("criticalInjury", criticalInjury);
+        return response;
+
+    }
+
 //    // Pobierz wszystkie obrażenia krytyczne dla admina
 //    public Map<String, Object> getAllCriticalInjuriesForAdmin() {
 //

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/criticalInjuries/CpRedCriticalInjuriesService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/criticalInjuries/CpRedCriticalInjuriesService.java
@@ -28,7 +28,7 @@ public class CpRedCriticalInjuriesService {
                         cpRedCriticalInjuries.getPatching(),
                         cpRedCriticalInjuries.getTreating()
                 )).toList();
-        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano wszystkie rodzaje obrażeń krytycznych.");
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano wszystkie rodzaje ran krytycznych.");
         response.put("criticalInjuries", cpRedCriticalInjuriesList);
         return response;
 
@@ -43,8 +43,8 @@ public class CpRedCriticalInjuriesService {
                         cpRedCriticalInjuries.getEffects(),
                         cpRedCriticalInjuries.getPatching(),
                         cpRedCriticalInjuries.getTreating()
-                )).orElseThrow(() -> new RuntimeException("Obrażenia krytyczne o id " + criticalInjuryId + " nie istnieją"));
-        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano obrażenia krytyczne o id " + criticalInjuryId);
+                )).orElseThrow(() -> new RuntimeException("Rany krytyczne o id " + criticalInjuryId + " nie istnieją"));
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano rany krytyczne o id " + criticalInjuryId);
         response.put("criticalInjury", criticalInjury);
         return response;
 
@@ -52,7 +52,7 @@ public class CpRedCriticalInjuriesService {
 
     public Map<String, Object> getAllCriticalInjuriesForAdmin() {
         List<CpRedCriticalInjuries> allCriticalInjuries = cpRedCriticalInjuriesRepository.findAll();
-        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano wszystkie obrażenia krytyczne.");
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano wszystkie rany krytyczne.");
         response.put("criticalInjuries", allCriticalInjuries);
         return response;
 
@@ -65,7 +65,7 @@ public class CpRedCriticalInjuriesService {
                 .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
 
         if (!currentUser.getRole().equals(UserRole.ROLE_ADMIN)) {
-            throw new IllegalStateException("Nie masz uprawnień do dodawania obrażeń krytycznych.");
+            throw new IllegalStateException("Nie masz uprawnień do dodawania ran krytycznych.");
         }
         if(cpRedCriticalInjuries.getInjuryPlace()==null ||
                 cpRedCriticalInjuries.getName()==null ||
@@ -75,35 +75,35 @@ public class CpRedCriticalInjuriesService {
             throw new IllegalStateException("Nie wszystkie pola zostały wypełnione.");
         }
         if (cpRedCriticalInjuries.getRollValue() <= 0) {
-            throw new IllegalStateException("Rzut nie może być ujemny lub równy zero.");
+            throw new IllegalStateException("Wartość rzutu nie może być ujemna lub równa zero.");
         }
         if(cpRedCriticalInjuriesRepository.existsByName(cpRedCriticalInjuries.getName())) {
-            throw new IllegalStateException("Obrażenia krytyczne o tej nazwie już istnieją.");
+            throw new IllegalStateException("Rany krytyczne o tej nazwie już istnieją.");
         }
         if (cpRedCriticalInjuries.getName().isEmpty() || cpRedCriticalInjuries.getName().trim().isEmpty()) {
-            throw new IllegalStateException("Nazwa obrażeń krytycznych nie może być pusta.");
+            throw new IllegalStateException("Nazwa ran krytycznych nie może być pusta.");
         }
         if (cpRedCriticalInjuries.getName().length() > 255) {
-            throw new IllegalStateException("Nazwa obrażeń krytycznych nie może być dłuższa niż 255 znaków.");
+            throw new IllegalStateException("Nazwa ran krytycznych nie może być dłuższa niż 255 znaków.");
         }
         if (cpRedCriticalInjuries.getEffects().isEmpty() || cpRedCriticalInjuries.getEffects().trim().isEmpty()) {
-            throw new IllegalStateException("Efekty obrażeń krytycznych nie mogą być puste.");
+            throw new IllegalStateException("Efekty ran krytycznych nie mogą być puste.");
         }
         if (cpRedCriticalInjuries.getEffects().length() > 500) {
-            throw new IllegalStateException("Efekty obrażeń krytycznych nie mogą być dłuższe niż 500 znaków.");
+            throw new IllegalStateException("Efekty ran krytycznych nie mogą być dłuższe niż 500 znaków.");
         }
 
         if (cpRedCriticalInjuries.getPatching().isEmpty() || cpRedCriticalInjuries.getPatching().trim().isEmpty()) {
-            throw new IllegalStateException("Łatanie obrażeń krytycznych nie może być puste.");
+            throw new IllegalStateException("Łatanie ran krytycznych nie może być puste.");
         }
         if (cpRedCriticalInjuries.getPatching().length() > 255) {
-            throw new IllegalStateException("Łatanie obrażeń krytycznych nie może być dłuższe niż 255 znaków.");
+            throw new IllegalStateException("Łatanie ran krytycznych nie może być dłuższe niż 255 znaków.");
         }
         if (cpRedCriticalInjuries.getTreating().isEmpty() || cpRedCriticalInjuries.getTreating().trim().isEmpty()) {
-            throw new IllegalStateException("Leczenie obrażeń krytycznych nie może być puste.");
+            throw new IllegalStateException("Leczenie ran krytycznych nie może być puste.");
         }
         if (cpRedCriticalInjuries.getTreating().length() > 255) {
-            throw new IllegalStateException("Leczenie obrażeń krytycznych nie może być dłuższe niż 255 znaków.");
+            throw new IllegalStateException("Leczenie ran krytycznych nie może być dłuższe niż 255 znaków.");
         }
         CpRedCriticalInjuries newCriticalInjury = new CpRedCriticalInjuries(
                 null,
@@ -115,7 +115,7 @@ public class CpRedCriticalInjuriesService {
                 cpRedCriticalInjuries.getTreating()
         );
         cpRedCriticalInjuriesRepository.save(newCriticalInjury);
-        return CustomReturnables.getOkResponseMap("Obrażenia krytyczne zostały dodane.");
+        return CustomReturnables.getOkResponseMap("Rany krytyczne zostały dodane.");
     }
 
     public Map<String, Object> updateCriticalInjury(Long criticalInjuryId, CpRedCriticalInjuries cpRedCriticalInjuries) {
@@ -125,13 +125,13 @@ public class CpRedCriticalInjuriesService {
                 .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
 
         if (!currentUser.getRole().equals(UserRole.ROLE_ADMIN)) {
-            throw new IllegalStateException("Nie masz uprawnień do dodawania obrażeń krytycznych.");
+            throw new IllegalStateException("Nie masz uprawnień do dodawania ran krytycznych.");
         }
         CpRedCriticalInjuries injuriesToUpdate = cpRedCriticalInjuriesRepository.findById(criticalInjuryId)
-                .orElseThrow(() -> new ResourceNotFoundException("Obrażenia krytyczne o id " + criticalInjuryId + " nie istnieją"));
+                .orElseThrow(() -> new ResourceNotFoundException("Rany krytyczne o id " + criticalInjuryId + " nie istnieją"));
 
         if(cpRedCriticalInjuries.getRollValue() <= 0) {
-            throw new IllegalStateException("Rzut nie może być ujemny lub równy zero.");
+            throw new IllegalStateException("Wartość rzutu nie może być ujemna lub równa zero.");
         }
         injuriesToUpdate.setRollValue(cpRedCriticalInjuries.getRollValue());
 
@@ -141,47 +141,47 @@ public class CpRedCriticalInjuriesService {
 
         if (cpRedCriticalInjuries.getName() != null) {
             if (cpRedCriticalInjuriesRepository.existsByName(cpRedCriticalInjuries.getName())) {
-                throw new IllegalStateException("Obrażenia krytyczne o tej nazwie już istnieją.");
+                throw new IllegalStateException("Rany krytyczne o tej nazwie już istnieją.");
             }
             if (cpRedCriticalInjuries.getName().isEmpty() || cpRedCriticalInjuries.getName().trim().isEmpty()) {
-                throw new IllegalStateException("Nazwa obrażeń krytycznych nie może być pusta.");
+                throw new IllegalStateException("Nazwa ran krytycznych nie może być pusta.");
             }
             if (cpRedCriticalInjuries.getName().length() > 255) {
-                throw new IllegalStateException("Nazwa obrażeń krytycznych nie może być dłuższa niż 255 znaków.");
+                throw new IllegalStateException("Nazwa ran krytycznych nie może być dłuższa niż 255 znaków.");
             }
             injuriesToUpdate.setName(cpRedCriticalInjuries.getName());
         }
 
         if (cpRedCriticalInjuries.getEffects() != null) {
             if (cpRedCriticalInjuries.getEffects().isEmpty() || cpRedCriticalInjuries.getEffects().trim().isEmpty()) {
-                throw new IllegalStateException("Efekty obrażeń krytycznych nie mogą być puste.");
+                throw new IllegalStateException("Efekty ran krytycznych nie mogą być puste.");
             }
             if (cpRedCriticalInjuries.getEffects().length() > 500) {
-                throw new IllegalStateException("Efekty obrażeń krytycznych nie mogą być dłuższe niż 500 znaków.");
+                throw new IllegalStateException("Efekty ran krytycznych nie mogą być dłuższe niż 500 znaków.");
             }
             injuriesToUpdate.setEffects(cpRedCriticalInjuries.getEffects());
         }
 
         if (cpRedCriticalInjuries.getPatching() != null) {
             if (cpRedCriticalInjuries.getPatching().isEmpty() || cpRedCriticalInjuries.getPatching().trim().isEmpty()) {
-                throw new IllegalStateException("Łatanie obrażeń krytycznych nie moźe być puste.");
+                throw new IllegalStateException("Łatanie ran krytycznych nie moźe być puste.");
             }
             if (cpRedCriticalInjuries.getPatching().length() > 255) {
-                throw new IllegalStateException("Łatanie obrażeń krytycznych nie może być dłuższe niż 255 znaków.");
+                throw new IllegalStateException("Łatanie ran krytycznych nie może być dłuższe niż 255 znaków.");
             }
             injuriesToUpdate.setPatching(cpRedCriticalInjuries.getPatching());
         }
 
         if (cpRedCriticalInjuries.getTreating() != null) {
             if (cpRedCriticalInjuries.getTreating().isEmpty() || cpRedCriticalInjuries.getTreating().trim().isEmpty()) {
-                throw new IllegalStateException("Leczenie obrażeń krytycznych nie moźe być puste.");
+                throw new IllegalStateException("Leczenie ran krytycznych nie moźe być puste.");
             }
             if (cpRedCriticalInjuries.getTreating().length() > 255) {
-                throw new IllegalStateException("Leczenie obrażeń krytycznych nie może być dłuższe niż 255 znaków.");
+                throw new IllegalStateException("Leczenie ran krytycznych nie może być dłuższe niż 255 znaków.");
             }
             injuriesToUpdate.setTreating(cpRedCriticalInjuries.getTreating());
         }
         cpRedCriticalInjuriesRepository.save(injuriesToUpdate);
-        return CustomReturnables.getOkResponseMap("Obrażenia krytyczne zostały zaktualizowane.");
+        return CustomReturnables.getOkResponseMap("Rany krytyczne zostały zaktualizowane.");
     }
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/cyberwares/CpRedCyberwaresService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/manual/cyberwares/CpRedCyberwaresService.java
@@ -95,7 +95,7 @@ public class CpRedCyberwaresService {
             throw new IllegalStateException("Wszczep o tej nazwie już istnieje.");
         }
         if (cpRedCyberwares.getName().isEmpty() || cpRedCyberwares.getName().trim().isEmpty()) {
-            throw new IllegalStateException("Nazwa broni nie może być pusta.");
+            throw new IllegalStateException("Nazwa wszczepu nie może być pusta.");
         }
         if (cpRedCyberwares.getName().length() > 255) {
             throw new IllegalStateException("Nazwa wszczepu nie może być dłuższa niż 255 znaków.");


### PR DESCRIPTION
Dodałem wszystkie endpointy do klasy ran krytycznych.

Funkcjonalności:

-     możliwość tworzenia nowych ran krytycznych (Admin)
-     edycja aktualnych ran krytycznych (Admin)
-     przegląd wszystkich zapisanych ran krytycznych (wszyscy)
-     możliwość wyszukania ran krytycznych po ID (wszyscy)
-     funkcja zwrotu wszystkich ran krytycznych w formie obiektów klasy (Admin)

Testowanie:

-     Zaloguj się jako Admin
-     Stwórz nowe rany krytyczne
-     Wyświetl wszystkie rany krytyczne
-     Zmodyfikuj rany krytyczne
-     Wyświetl rany krytyczne po ID
-     Wyświetl rany krytyczne w formie obiektu

Wszystkie endpointy są w jetcliencie. Cała klasa opiera się o erd.
