### PR TITLE
Service/controller dla cp red custom critical injuries

### DIFF
--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -905,6 +905,75 @@
                                   </option>
                                   <option name="sortWeight" value="2000000" />
                                 </folderState>
+                                <folderState>
+                                  <option name="id" value="69a6df04-5032-441b-bc50-19f7772d812c" />
+                                  <option name="name" value="CustomCriticalInjuries" />
+                                  <option name="requests">
+                                    <list>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  gameId: 1,&#10;  injuryPlace: &quot;HEAD&quot;,&#10;  name: &quot;rany&quot;,&#10;  effects: &quot;nie zabija&quot;,&#10;  patching: &quot;none&quot;,&#10;  treating: &quot;yes&quot;&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Dodaje customowy rany krytyczne" />
+                                        <option name="id" value="d98f6feb-9920-4dc2-a304-8acbb1622183" />
+                                        <option name="method" value="POST" />
+                                        <option name="name" value="Dodaj rany krytyczne" />
+                                        <option name="sortWeight" value="1000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/customCriticalInjuries/add" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  gameId: 1,&#10;  injuryPlace: &quot;HEAD&quot;,&#10;  name: &quot;nowe rany&quot;,&#10;  effects: &quot;zabija&quot;,&#10;  patching: &quot;none&quot;,&#10;  treating: &quot;none&quot;&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Pozwala zmienić dane w customowych ranach krytycznych" />
+                                        <option name="id" value="835fb46f-5306-4ffa-b79b-34033117d58a" />
+                                        <option name="method" value="PUT" />
+                                        <option name="name" value="Modyfikuj rany krytyczne" />
+                                        <option name="sortWeight" value="2000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/customCriticalInjuries/update/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Pobiera wszystkie customowe rany krytyczne" />
+                                        <option name="id" value="bbe49238-be29-4553-8962-98b61f224300" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobierz wszystkie rany krytyczne" />
+                                        <option name="sortWeight" value="3000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/customCriticalInjuries/all" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="pobiera customowe rany krytyczne po id" />
+                                        <option name="id" value="d7806575-02e5-441c-9f7b-5c5f7473fd02" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobierz rany krytyczne po id" />
+                                        <option name="sortWeight" value="4000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/customCriticalInjuries/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="pobiera customowe rany krytyczne z konkretnej gry" />
+                                        <option name="id" value="af68e475-0770-4e63-8253-c02033feadf7" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobierz wszystkie rany krytyczne po gameId" />
+                                        <option name="sortWeight" value="5000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/customCriticalInjuries/game/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="pobiera wszystkie customowe rany krytyczne w formie obiektów" />
+                                        <option name="id" value="27b5b316-3a90-4f4d-ad5e-cb82c09eb348" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobierz wszystkie rany krytyczne dla admina" />
+                                        <option name="sortWeight" value="6000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/customCriticalInjuries/all" />
+                                      </requestState>
+                                    </list>
+                                  </option>
+                                  <option name="sortWeight" value="3000000" />
+                                </folderState>
                               </list>
                             </option>
                             <option name="id" value="be478e01-3cd6-4b0a-bd25-b519ab021bde" />

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesController.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesController.java
@@ -12,18 +12,23 @@ import java.util.Map;
 public class CpRedCustomCriticalInjuriesController {
     private final CpRedCustomCriticalInjuriesService cpRedCustomCriticalInjuriesService;
 
-//    // ============ User methods ============
-//    // Pobierz wszystkie customowe rany krytyczne
-//    @GetMapping(path = "/rpgSystems/cpRed/customCriticalInjuries/all")
-//    public Map<String, Object> getAllCustomCriticalInjuries() { // List<CpRedCustomCriticalInjuriesDTO>
-//        return cpRedCustomCriticalInjuriesService.getAllCustomCriticalInjuries();
-//    }
-//    // Pobierz customową ranę krytyczną po id
-//    @GetMapping(path = "/rpgSystems/cpRed/customCriticalInjuries/{customCriticalInjuryId}")
-//    public Map<String, Object> getCustomCriticalInjuryById(
-//            @PathVariable("customCriticalInjuryId") Long customCriticalInjuryId) { // CpRedCustomCriticalInjuriesDTO
-//        return cpRedCustomCriticalInjuriesService.getCustomCriticalInjuryById(customCriticalInjuryId);
-//    }
+
+    @GetMapping(path = "/rpgSystems/cpRed/customCriticalInjuries/all")
+    public Map<String, Object> getAllCustomCriticalInjuries() { // List<CpRedCustomCriticalInjuriesDTO>
+        return cpRedCustomCriticalInjuriesService.getAllCustomCriticalInjuries();
+    }
+
+    @GetMapping(path = "/rpgSystems/cpRed/customCriticalInjuries/{customCriticalInjuryId}")
+    public Map<String, Object> getCustomCriticalInjuryById(
+            @PathVariable("customCriticalInjuryId") Long customCriticalInjuryId) { // CpRedCustomCriticalInjuriesDTO
+        return cpRedCustomCriticalInjuriesService.getCustomCriticalInjuryById(customCriticalInjuryId);
+    }
+
+    @GetMapping(path = "/rpgSystems/cpRed/customCriticalInjuries/game/{gameId}")
+    public Map<String, Object> getCustomCriticalInjuryByGame(@PathVariable("gameId") Long gameId) {
+        return cpRedCustomCriticalInjuriesService.getCustomCriticalInjuryByGame(gameId);
+    }
+
 //    // Dodać customową ranę krytyczną
 //    @PostMapping(path = "/rpgSystems/cpRed/customCriticalInjuries/add")
 //    public Map<String, Object> addCustomCriticalInjury(

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesController.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesController.java
@@ -29,23 +29,20 @@ public class CpRedCustomCriticalInjuriesController {
         return cpRedCustomCriticalInjuriesService.getCustomCriticalInjuryByGame(gameId);
     }
 
-//    // Dodać customową ranę krytyczną
-//    @PostMapping(path = "/rpgSystems/cpRed/customCriticalInjuries/add")
-//    public Map<String, Object> addCustomCriticalInjury(
-//            @RequestBody CpRedCustomCriticalInjuries cpRedCustomCriticalInjuries) {
-//        return cpRedCustomCriticalInjuriesService.addCustomCriticalInjury(cpRedCustomCriticalInjuries);
-//    }
+    // Dodać customową ranę krytyczną
+    @PostMapping(path = "/rpgSystems/cpRed/customCriticalInjuries/add")
+    public Map<String, Object> addCustomCriticalInjury(
+            @RequestBody CpRedCustomCriticalInjuriesRequest @RequestBody cpRedCustomCriticalInjuries) {
+        return cpRedCustomCriticalInjuriesService.addCustomCriticalInjury(cpRedCustomCriticalInjuries);
+    }
 //    // Modyfikować customową ranę krytyczną
 //    @PutMapping(path = "/rpgSystems/cpRed/customCriticalInjuries/update/{customCriticalInjuryId}")
 //    public Map<String, Object> updateCustomCriticalInjury(@PathVariable("customCriticalInjuryId") Long customCriticalInjuryId,
 //                                                           @RequestBody CpRedCustomCriticalInjuries cpRedCustomCriticalInjuries) {
 //        return cpRedCustomCriticalInjuriesService.updateCustomCriticalInjury(customCriticalInjuryId, cpRedCustomCriticalInjuries);
 //    }
-//
-//    // ============ Admin methods ============
-//    // Pobierz wszystkie customowe rany krytyczne dla admina
-//    @GetMapping(path = "/admin/rpgSystems/cpRed/customCriticalInjuries/all")
-//    public Map<String, Object> getAllCustomCriticalInjuriesForAdmin() { // List<CpRedCustomCriticalInjuries>
-//        return cpRedCustomCriticalInjuriesService.getAllCustomCriticalInjuriesForAdmin();
-//    }
+    @GetMapping(path = "/admin/rpgSystems/cpRed/customCriticalInjuries/all")
+    public Map<String, Object> getAllCustomCriticalInjuriesForAdmin() { // List<CpRedCustomCriticalInjuries>
+        return cpRedCustomCriticalInjuriesService.getAllCustomCriticalInjuriesForAdmin();
+    }
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesController.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesController.java
@@ -29,18 +29,17 @@ public class CpRedCustomCriticalInjuriesController {
         return cpRedCustomCriticalInjuriesService.getCustomCriticalInjuryByGame(gameId);
     }
 
-    // Dodać customową ranę krytyczną
     @PostMapping(path = "/rpgSystems/cpRed/customCriticalInjuries/add")
     public Map<String, Object> addCustomCriticalInjury(
-            @RequestBody CpRedCustomCriticalInjuriesRequest @RequestBody cpRedCustomCriticalInjuries) {
+            @RequestBody CpRedCustomCriticalInjuriesRequest cpRedCustomCriticalInjuries) {
         return cpRedCustomCriticalInjuriesService.addCustomCriticalInjury(cpRedCustomCriticalInjuries);
     }
-//    // Modyfikować customową ranę krytyczną
-//    @PutMapping(path = "/rpgSystems/cpRed/customCriticalInjuries/update/{customCriticalInjuryId}")
-//    public Map<String, Object> updateCustomCriticalInjury(@PathVariable("customCriticalInjuryId") Long customCriticalInjuryId,
-//                                                           @RequestBody CpRedCustomCriticalInjuries cpRedCustomCriticalInjuries) {
-//        return cpRedCustomCriticalInjuriesService.updateCustomCriticalInjury(customCriticalInjuryId, cpRedCustomCriticalInjuries);
-//    }
+
+    @PutMapping(path = "/rpgSystems/cpRed/customCriticalInjuries/update/{customCriticalInjuryId}")
+    public Map<String, Object> updateCustomCriticalInjury(@PathVariable("customCriticalInjuryId") Long customCriticalInjuryId,
+                                                           @RequestBody CpRedCustomCriticalInjuriesRequest cpRedCustomCriticalInjuries) {
+        return cpRedCustomCriticalInjuriesService.updateCustomCriticalInjury(customCriticalInjuryId, cpRedCustomCriticalInjuries);
+    }
     @GetMapping(path = "/admin/rpgSystems/cpRed/customCriticalInjuries/all")
     public Map<String, Object> getAllCustomCriticalInjuriesForAdmin() { // List<CpRedCustomCriticalInjuries>
         return cpRedCustomCriticalInjuriesService.getAllCustomCriticalInjuriesForAdmin();

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesRepository.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 @Repository
 public interface CpRedCustomCriticalInjuriesRepository extends JpaRepository<CpRedCustomCriticalInjuries, Long> {
     List<CpRedCustomCriticalInjuries> findAllByGameId(Game game);
+    Boolean existsByNameAndGameId(String name, Game game);
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesRepository.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesRepository.java
@@ -1,8 +1,12 @@
 package dev.goral.rpgmanager.rpgSystems.cpRed.custom.customCriticalInjuries;
 
+import dev.goral.rpgmanager.game.Game;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CpRedCustomCriticalInjuriesRepository extends JpaRepository<CpRedCustomCriticalInjuries, Long> {
+    List<CpRedCustomCriticalInjuries> findAllByGameId(Game game);
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesRequest.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesRequest.java
@@ -1,0 +1,20 @@
+package dev.goral.rpgmanager.rpgSystems.cpRed.custom.customCriticalInjuries;
+
+import dev.goral.rpgmanager.rpgSystems.cpRed.manual.criticalInjuries.CpRedCriticalInjuriesInjuryPlace;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CpRedCustomCriticalInjuriesRequest {
+    private Long gameId;
+    private CpRedCriticalInjuriesInjuryPlace injuryPlace;
+    private String name;
+    private String effects;
+    private String patching;
+    private String treating;
+}

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesService.java
@@ -1,6 +1,7 @@
 package dev.goral.rpgmanager.rpgSystems.cpRed.custom.customCriticalInjuries;
 
 import dev.goral.rpgmanager.security.CustomReturnables;
+import dev.goral.rpgmanager.security.exceptions.ResourceNotFoundException;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -28,11 +29,22 @@ public class CpRedCustomCriticalInjuriesService {
         return response;
 
     }
-//
-//    // Pobierz customową ranę krytyczną po id
-//    public Map<String, Object> getCustomCriticalInjuryById(Long customCriticalInjuryId) {
-//
-//    }
+
+    // Pobierz customową ranę krytyczną po id
+    public Map<String, Object> getCustomCriticalInjuryById(Long customCriticalInjuryId) {
+        CpRedCustomCriticalInjuriesDTO customCriticalInjuries = cpRedCustomCriticalInjuriesRepository.findById(customCriticalInjuryId)
+                .map(CpRedCustomCriticalInjuries -> new CpRedCustomCriticalInjuriesDTO(
+                        CpRedCustomCriticalInjuries.getGameId().getId(),
+                        CpRedCustomCriticalInjuries.getInjuryPlace().toString(),
+                        CpRedCustomCriticalInjuries.getName(),
+                        CpRedCustomCriticalInjuries.getEffects(),
+                        CpRedCustomCriticalInjuries.getPatching(),
+                        CpRedCustomCriticalInjuries.getTreating()
+                )).orElseThrow(() -> new ResourceNotFoundException("Customowe rany krytyczne o id " + customCriticalInjuryId + " nie istnieją."));
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Customowa rana krytyczna została pobrana");
+        response.put("customCriticalInjuries", customCriticalInjuries);
+        return response;
+    }
 //
 //    // Dodać customową ranę krytyczną
 //    public Map<String, Object> addCustomCriticalInjury(CpRedCustomCriticalInjuries cpRedCustomCriticalInjuries) {

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesService.java
@@ -1,8 +1,10 @@
 package dev.goral.rpgmanager.rpgSystems.cpRed.custom.customCriticalInjuries;
 
+import dev.goral.rpgmanager.security.CustomReturnables;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -11,10 +13,21 @@ import java.util.Map;
 public class CpRedCustomCriticalInjuriesService {
     private final CpRedCustomCriticalInjuriesRepository cpRedCustomCriticalInjuriesRepository;
 
-//    // Pobierz wszystkie customowe rany krytyczne
-//    public Map<String, Object> getAllCustomCriticalInjuries() {
-//
-//    }
+    public Map<String, Object> getAllCustomCriticalInjuries() {
+        List<CpRedCustomCriticalInjuriesDTO> allCustomCriticalInjuries = cpRedCustomCriticalInjuriesRepository.findAll().stream()
+                .map(CpRedCustomCriticalInjuries -> new CpRedCustomCriticalInjuriesDTO(
+                        CpRedCustomCriticalInjuries.getGameId().getId(),
+                        CpRedCustomCriticalInjuries.getInjuryPlace().toString(),
+                        CpRedCustomCriticalInjuries.getName(),
+                        CpRedCustomCriticalInjuries.getEffects(),
+                        CpRedCustomCriticalInjuries.getPatching(),
+                        CpRedCustomCriticalInjuries.getTreating()
+                )).toList();
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Customowe rany krytyczne zostały pobrane");
+        response.put("customCriticalInjuries", allCustomCriticalInjuries);
+        return response;
+
+    }
 //
 //    // Pobierz customową ranę krytyczną po id
 //    public Map<String, Object> getCustomCriticalInjuryById(Long customCriticalInjuryId) {

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesService.java
@@ -94,9 +94,12 @@ public class CpRedCustomCriticalInjuriesService {
 //
 //    }
 //
-//    // Pobierz wszystkie customowe rany krytyczne dla admina
-//    public Map<String, Object> getAllCustomCriticalInjuriesForAdmin() {
-//
-//    }
+    public Map<String, Object> getAllCustomCriticalInjuriesForAdmin() {
+    List<CpRedCustomCriticalInjuries> allCustomCriticalInjuries = cpRedCustomCriticalInjuriesRepository.findAll();
+
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Customowe rany krytyczne zostały pobrane dla administratora");
+        response.put("customCriticalInjuries", allCustomCriticalInjuries);
+        return response;
+    }
 
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesService.java
@@ -2,8 +2,10 @@ package dev.goral.rpgmanager.rpgSystems.cpRed.custom.customCriticalInjuries;
 
 import dev.goral.rpgmanager.game.Game;
 import dev.goral.rpgmanager.game.GameRepository;
+import dev.goral.rpgmanager.game.GameStatus;
 import dev.goral.rpgmanager.game.gameUsers.GameUsers;
 import dev.goral.rpgmanager.game.gameUsers.GameUsersRepository;
+import dev.goral.rpgmanager.game.gameUsers.GameUsersRole;
 import dev.goral.rpgmanager.rpgSystems.cpRed.custom.customArmors.CpRedCustomArmorsDTO;
 import dev.goral.rpgmanager.security.CustomReturnables;
 import dev.goral.rpgmanager.security.exceptions.ResourceNotFoundException;
@@ -83,11 +85,73 @@ public class CpRedCustomCriticalInjuriesService {
         return response;
     }
 
-//
-//    // Dodać customową ranę krytyczną
-//    public Map<String, Object> addCustomCriticalInjury(CpRedCustomCriticalInjuries cpRedCustomCriticalInjuries) {
-//
-//    }
+
+    public Map<String, Object> addCustomCriticalInjury(CpRedCustomCriticalInjuriesRequest cpRedCustomCriticalInjuries) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
+        if(cpRedCustomCriticalInjuries.getGameId() == null||
+            cpRedCustomCriticalInjuries.getInjuryPlace()==null||
+            cpRedCustomCriticalInjuries.getName()==null||
+            cpRedCustomCriticalInjuries.getEffects()==null||
+            cpRedCustomCriticalInjuries.getPatching()==null||
+            cpRedCustomCriticalInjuries.getTreating()==null) {
+            throw new IllegalStateException("Wszystkie pola muszą być wypełnione.");
+        }
+        Game game = gameRepository.findById(cpRedCustomCriticalInjuries.getGameId())
+                .orElseThrow(() -> new ResourceNotFoundException("Gra o id " + cpRedCustomCriticalInjuries.getGameId() + " nie istnieje."));
+        if (game.getStatus() != GameStatus.ACTIVE) {
+            throw new IllegalStateException("Gra o id " + cpRedCustomCriticalInjuries.getGameId() + " nie jest aktywna.");
+        }
+        GameUsers gameUsers = gameUsersRepository.findGameUsersByUserIdAndGameId(currentUser.getId(), cpRedCustomCriticalInjuries.getGameId())
+                .orElseThrow(() -> new ResourceNotFoundException("Nie należysz do podanej gry."));
+        if (gameUsers.getRole() != GameUsersRole.GAMEMASTER) {
+            throw new IllegalStateException("Tylko GM może dodać pancerz do gry.");
+        }
+        if (cpRedCustomCriticalInjuriesRepository.existsByNameAndGameId(cpRedCustomCriticalInjuries.getName(), game)) {
+            throw new IllegalStateException("Customowe rany krytyczne o tej nazwie już istnieje w tej grze.");
+        }
+        if (cpRedCustomCriticalInjuries.getName().isEmpty() ||
+                cpRedCustomCriticalInjuries.getName().trim().isEmpty()) {
+            throw new IllegalStateException("Nazwa ran krytycznych nie może być pusta.");
+        }
+        if (cpRedCustomCriticalInjuries.getName().length() > 255) {
+            throw new IllegalStateException("Nazwa ran krytycznych nie może być dłuższa niż 255 znaków.");
+        }
+        if (cpRedCustomCriticalInjuries.getEffects().isEmpty() ||
+                cpRedCustomCriticalInjuries.getEffects().trim().isEmpty()) {
+            throw new IllegalStateException("Efekty ran krytycznych nie mogą być puste.");
+        }
+        if (cpRedCustomCriticalInjuries.getEffects().length() > 500) {
+            throw new IllegalStateException("Efekty ran krytycznych nie mogą być dłuższe niż 500 znaków.");
+        }
+        if (cpRedCustomCriticalInjuries.getPatching().isEmpty() ||
+                cpRedCustomCriticalInjuries.getPatching().trim().isEmpty()) {
+            throw new IllegalStateException("Łatanie ran krytycznych nie może być puste.");
+        }
+        if (cpRedCustomCriticalInjuries.getPatching().length() > 255) {
+            throw new IllegalStateException("Łatanie ran krytycznych nie może być dłuższe niż 255 znaków.");
+        }
+        if (cpRedCustomCriticalInjuries.getTreating().isEmpty() ||
+                cpRedCustomCriticalInjuries.getTreating().trim().isEmpty()) {
+            throw new IllegalStateException("Leczenie ran krytycznych nie może być puste.");
+        }
+        if (cpRedCustomCriticalInjuries.getTreating().length() > 255) {
+            throw new IllegalStateException("Leczenie ran krytycznych nie może być dłuższe niż 255 znaków.");
+        }
+        CpRedCustomCriticalInjuries newCustomCriticalInjuries = new CpRedCustomCriticalInjuries(
+                null,
+                game,
+                cpRedCustomCriticalInjuries.getInjuryPlace(),
+                cpRedCustomCriticalInjuries.getName(),
+                cpRedCustomCriticalInjuries.getEffects(),
+                cpRedCustomCriticalInjuries.getPatching(),
+                cpRedCustomCriticalInjuries.getTreating()
+        );
+        cpRedCustomCriticalInjuriesRepository.save(newCustomCriticalInjuries);
+        return CustomReturnables.getOkResponseMap("Customowe rany krytyczne zostały dodane.");
+    }
 //
 //    // Modyfikować customową ranę krytyczną
 //    public Map<String, Object> updateCustomCriticalInjury(Long customCriticalInjuryId, CpRedCustomCriticalInjuries cpRedCustomCriticalInjuries) {


### PR DESCRIPTION
Dodałem wszystkie endpointy do klasy customowych ran krytycznych.

Funkcjonalności:

-     możliwość tworzenia nowych ran krytycznych (GM)
-     edycja aktualnych ran krytycznych (GM)
-     przegląd wszystkich zapisanych ran krytycznych (wszyscy)
-     możliwość wyszukania ran krytycznych po ID (wszyscy)
-     przegląd wszystkich zapisanych ran krytycznych po ID gry (wszyscy gracze konkretnej gry)
-     funkcja zwrotu wszystkich ran krytycznych w formie obiektów klasy (Admin)

Testowanie:

-     Zaloguj się jako User 1 (GM)
-     Stwórz nową grę
-     Stwórz nowe rany krytyczne
-     Wyświetl wszystkie rany krytyczne
-     Wyświetl rany krytyczne po ID
-     Wyświetl rany krytyczne po ID gry
-     Zmodyfikuj rany krytyczne
-     Wyloguj się
-     Zaloguj się jako Admin
-     Wyświetl rany krytyczne w formie obiektu

Wszystkie endpointy są w jetcliencie. Cała klasa opiera się o erd.