### PR TITLE
Service/controller dla cp red custom cyberwares

### DIFF
--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -998,7 +998,7 @@
                                       <requestState>
                                         <option name="body">
                                           <bodyState>
-                                            <option name="raw" value="{&#10;  gameId: 1,&#10;  name: &quot;Wszczep własny 1.0&quot;,&#10;  mountPlace: &quot;EYE&quot;,&#10;  requirements: &quot;none&quot;,&#10;  humanityLoss: &quot;2 (2K6)&quot;,&#10;  size: 5,&#10;  installationPlace: &quot;CLINIC&quot;,&#10;  price: 100,&#10;  availability: &quot;CHEAP&quot;,&#10;  description: &quot;słaby wszczep&quot;&#10;}" />
+                                            <option name="raw" value="{&#10;  gameId: 1,&#10;  name: &quot;Wszczep własny 1.0&quot;,&#10;  mountPlace: &quot;NEURALWARE&quot;,&#10;  requirements: &quot;none&quot;,&#10;  humanityLoss: &quot;2 (2K6)&quot;,&#10;  size: 5,&#10;  installationPlace: &quot;CLINIC&quot;,&#10;  price: 100,&#10;  availability: &quot;CHEAP&quot;,&#10;  description: &quot;słaby wszczep&quot;&#10;}" />
                                             <option name="type" value="JSON" />
                                           </bodyState>
                                         </option>
@@ -1012,7 +1012,7 @@
                                       <requestState>
                                         <option name="body">
                                           <bodyState>
-                                            <option name="raw" value="{&#10;  gameId: 1,&#10;  name: &quot;Wszczep własny 2.0&quot;,&#10;  mountPlace: &quot;EYE&quot;,&#10;  requirements: &quot;none&quot;,&#10;  humanityLoss: &quot;2 (2K6)&quot;,&#10;  size: 1,&#10;  installationPlace: &quot;CLINIC&quot;,&#10;  price: 150,&#10;  availability: &quot;CHEAP&quot;,&#10;  description: &quot;inny wszczep&quot;&#10;}" />
+                                            <option name="raw" value="{&#10;  gameId: 1,&#10;  name: &quot;Wszczep własny 2.0&quot;,&#10;  mountPlace: &quot;NEURALWARE&quot;,&#10;  requirements: &quot;none&quot;,&#10;  humanityLoss: &quot;2 (2K6)&quot;,&#10;  size: 1,&#10;  installationPlace: &quot;CLINIC&quot;,&#10;  price: 150,&#10;  availability: &quot;CHEAP&quot;,&#10;  description: &quot;inny wszczep&quot;&#10;}" />
                                             <option name="type" value="JSON" />
                                           </bodyState>
                                         </option>

--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -990,7 +990,75 @@
                                   </option>
                                   <option name="sortWeight" value="2000000" />
                                 </folderState>
-
+                                <folderState>
+                                  <option name="id" value="81c48867-811a-4a80-84f6-32f068bc9adb" />
+                                  <option name="name" value="CustomCyberware" />
+                                  <option name="requests">
+                                    <list>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  gameId: 1,&#10;  name: &quot;Wszczep własny 1.0&quot;,&#10;  mountPlace: &quot;EYE&quot;,&#10;  requirements: &quot;none&quot;,&#10;  humanityLoss: &quot;2 (2K6)&quot;,&#10;  size: 5,&#10;  installationPlace: &quot;CLINIC&quot;,&#10;  price: 100,&#10;  availability: &quot;CHEAP&quot;,&#10;  description: &quot;słaby wszczep&quot;&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Dodaje customowy wszczep" />
+                                        <option name="id" value="aec1a04b-0583-479d-ae98-fb0a7ad977f1" />
+                                        <option name="method" value="POST" />
+                                        <option name="name" value="Dodaj wszczep" />
+                                        <option name="sortWeight" value="1000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/customCyberware/add" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  gameId: 1,&#10;  name: &quot;Wszczep własny 2.0&quot;,&#10;  mountPlace: &quot;EYE&quot;,&#10;  requirements: &quot;none&quot;,&#10;  humanityLoss: &quot;2 (2K6)&quot;,&#10;  size: 1,&#10;  installationPlace: &quot;CLINIC&quot;,&#10;  price: 150,&#10;  availability: &quot;CHEAP&quot;,&#10;  description: &quot;inny wszczep&quot;&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Pozwala zmienić dane w customowym wszczepie" />
+                                        <option name="id" value="4b61b98a-cf37-44a6-b558-42cc60908d31" />
+                                        <option name="method" value="PUT" />
+                                        <option name="name" value="Modyfikuj wszczep" />
+                                        <option name="sortWeight" value="2000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/customCyberware/update/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Pobiera wszystkie customowe wszczepy" />
+                                        <option name="id" value="4f445c04-6a8f-48d5-aaf8-59904e472c64" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobierz wszystkie wszczepy" />
+                                        <option name="sortWeight" value="3000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/customCyberware/all" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="pobiera customowy wszczep po id" />
+                                        <option name="id" value="19b2aad0-0a77-4c8f-82e6-081e0f2f0a51" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobierz wszczep po id" />
+                                        <option name="sortWeight" value="4000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/customCyberware/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="pobiera customowe wszczepy z konkretnej gry" />
+                                        <option name="id" value="ce50153c-dfaa-4883-bf53-69e3450e9d5c" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobierz wszystkie wszczepy po gameId" />
+                                        <option name="sortWeight" value="5000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/customCyberware/game/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="pobiera wszystkie customowe wszczepy w formie obiektów" />
+                                        <option name="id" value="5ec90dfe-367b-409c-af16-95964749bc2c" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobierz wszystkie wszczepy dla admina" />
+                                        <option name="sortWeight" value="6000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/customCyberware/all" />
+                                      </requestState>
+                                    </list>
+                                  </option>
+                                  <option name="sortWeight" value="3000000" />
+                                </folderState>
                               </list>
                             </option>
                             <option name="id" value="be478e01-3cd6-4b0a-bd25-b519ab021bde" />

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customArmors/CpRedCustomArmorsService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customArmors/CpRedCustomArmorsService.java
@@ -258,7 +258,6 @@ public class CpRedCustomArmorsService {
 
     public Map<String, Object> getAllCustomArmorsForAdmin() {
         List<CpRedCustomArmors> allCustomArmorsList = cpRedCustomArmorsRepository.findAll();
-
         Map<String, Object> response = CustomReturnables.getOkResponseMap("Customowe pancerze zostały pobrane dla administratora.");
         response.put("customArmors", allCustomArmorsList);
         return response;

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresController.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresController.java
@@ -13,33 +13,34 @@ import java.util.Map;
 public class CpRedCustomCyberwaresController {
     private CpRedCustomCyberwaresService cpRedCustomCyberwaresService;
 
-//    // ============ User methods ============
-//    // Pobierz wszystkie cyberware
-//    @GetMapping(path = "/rpgSystems/cpRed/customCyberware/all")
-//    public Map<String, Object> getAllCyberware() { // List<CpRedCustomCyberwaresDTO>
-//        return cpRedCustomCyberwaresService.getAllCyberware();
-//    }
-//    // Pobierz cyberware po id
-//    @GetMapping(path = "/rpgSystems/cpRed/customCyberware/{cyberwareId}")
-//    public Map<String, Object> getCyberwareById(@PathVariable("cyberwareId") Long cyberwareId) { // CpRedCustomCyberwaresDTO
-//        return cpRedCustomCyberwaresService.getCyberwareById(cyberwareId);
-//    }
-//    // Doadaj cyberware
-//    @PostMapping(path = "/rpgSystems/cpRed/customCyberware/add")
-//    public Map<String, Object> addCyberware(@RequestBody CpRedCustomCyberwares cpRedCustomCyberwares) {
-//        return cpRedCustomCyberwaresService.addCyberware(cpRedCustomCyberwares);
-//    }
-//    // Modyfikować cyberware
-//    @PutMapping(path = "/rpgSystems/cpRed/customCyberware/update/{cyberwareId}")
-//    public Map<String, Object> updateCyberware(@PathVariable("cyberwareId") Long cyberwareId,
-//                                               @RequestBody CpRedCustomCyberwares cpRedCustomCyberwares) {
-//        return cpRedCustomCyberwaresService.updateCyberware(cyberwareId, cpRedCustomCyberwares);
-//    }
-//
-//    // ============ Admin methods ============
-//    // Pobierz wszystkie cyberware dla admina
-//    @GetMapping(path = "/admin/rpgSystems/cpRed/customCyberware/all")
-//    public Map<String, Object> getAllCyberwareForAdmin() { // List<CpRedCustomCyberwares>
-//        return cpRedCustomCyberwaresService.getAllCyberwareForAdmin();
-//    }
+    @GetMapping(path = "/rpgSystems/cpRed/customCyberware/all")
+    public Map<String, Object> getAllCyberware() {
+        return cpRedCustomCyberwaresService.getAllCyberware();
+    }
+
+    @GetMapping(path = "/rpgSystems/cpRed/customCyberware/{cyberwareId}")
+    public Map<String, Object> getCyberwareById(@PathVariable("cyberwareId") Long cyberwareId) {
+        return cpRedCustomCyberwaresService.getCyberwareById(cyberwareId);
+    }
+    @GetMapping(path = "/rpgSystems/cpRed/customCyberware/game/{gameId}")
+    public Map<String, Object> getCyberwareByGame(@PathVariable("gameId") Long gameId) {
+        return cpRedCustomCyberwaresService.getCyberwareByGame(gameId);
+    }
+
+
+    @PostMapping(path = "/rpgSystems/cpRed/customCyberware/add")
+    public Map<String, Object> addCyberware(@RequestBody CpRedCustomCyberwaresRequest cpRedCustomCyberwares) {
+        return cpRedCustomCyberwaresService.addCyberware(cpRedCustomCyberwares);
+    }
+
+    @PutMapping(path = "/rpgSystems/cpRed/customCyberware/update/{cyberwareId}")
+    public Map<String, Object> updateCyberware(@PathVariable("cyberwareId") Long cyberwareId,
+                                               @RequestBody CpRedCustomCyberwaresRequest cpRedCustomCyberwares) {
+        return cpRedCustomCyberwaresService.updateCyberware(cyberwareId, cpRedCustomCyberwares);
+    }
+
+    @GetMapping(path = "/admin/rpgSystems/cpRed/customCyberware/all")
+    public Map<String, Object> getAllCyberwareForAdmin() {
+        return cpRedCustomCyberwaresService.getAllCyberwareForAdmin();
+    }
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresRepository.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresRepository.java
@@ -1,8 +1,13 @@
 package dev.goral.rpgmanager.rpgSystems.cpRed.custom.customCyberwares;
 
+import dev.goral.rpgmanager.game.Game;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CpRedCustomCyberwaresRepository extends JpaRepository<CpRedCustomCyberwares, Long> {
+    boolean existsByNameAndGameId(String name, Game game);
+    List<CpRedCustomCyberwares> findAllByGameId(Game game);
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresRequest.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresRequest.java
@@ -1,0 +1,26 @@
+package dev.goral.rpgmanager.rpgSystems.cpRed.custom.customCyberwares;
+
+import dev.goral.rpgmanager.rpgSystems.cpRed.items.CpRedItemsAvailability;
+import dev.goral.rpgmanager.rpgSystems.cpRed.manual.cyberwares.CpRedCyberwaresInstallationPlace;
+import dev.goral.rpgmanager.rpgSystems.cpRed.manual.cyberwares.CpRedCyberwaresMountPlace;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CpRedCustomCyberwaresRequest {
+    private Long gameId;
+    private String name;
+    private CpRedCyberwaresMountPlace mountPlace;
+    private String requirements;
+    private String humanityLoss;
+    private int size=-1;
+    private CpRedCyberwaresInstallationPlace installationPlace;
+    private int price=-1;
+    private CpRedItemsAvailability availability;
+    private String description;
+}

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresService.java
@@ -1,8 +1,15 @@
 package dev.goral.rpgmanager.rpgSystems.cpRed.custom.customCyberwares;
 
+import dev.goral.rpgmanager.game.GameRepository;
+import dev.goral.rpgmanager.game.gameUsers.GameUsersRepository;
+import dev.goral.rpgmanager.rpgSystems.cpRed.custom.customArmors.CpRedCustomArmors;
+import dev.goral.rpgmanager.rpgSystems.cpRed.custom.customArmors.CpRedCustomArmorsService;
+import dev.goral.rpgmanager.security.CustomReturnables;
+import dev.goral.rpgmanager.user.UserRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -10,11 +17,27 @@ import java.util.Map;
 @AllArgsConstructor
 public class CpRedCustomCyberwaresService {
     private final CpRedCustomCyberwaresRepository cpRedCustomCyberwaresRepository;
-
-//    // Pobierz wszystkie cyberware
-//    public Map<String, Object> getAllCyberware() {
-//
-//    }
+    private final GameRepository gameRepository;
+    private final UserRepository userRepository;
+    private final GameUsersRepository gameUsersRepository;
+    public Map<String, Object> getAllCyberware() {
+        List<CpRedCustomCyberwaresDTO> allCustomCyberwares=cpRedCustomCyberwaresRepository.findAll().stream()
+                .map(CpRedCustomCyberwares -> new CpRedCustomCyberwaresDTO(
+                        CpRedCustomCyberwares.getGameId().getId(),
+                        CpRedCustomCyberwares.getName(),
+                        CpRedCustomCyberwares.getMountPlace().toString(),
+                        CpRedCustomCyberwares.getRequirements(),
+                        CpRedCustomCyberwares.getHumanityLoss(),
+                        CpRedCustomCyberwares.getSize(),
+                        CpRedCustomCyberwares.getInstallationPlace().toString(),
+                        CpRedCustomCyberwares.getPrice(),
+                        CpRedCustomCyberwares.getAvailability().toString(),
+                        CpRedCustomCyberwares.getDescription()
+                )).toList();
+        Map<String,Object> response= CustomReturnables.getOkResponseMap("Customowe wszczepy zostały pobrane.");
+        response.put("customCyberwares",allCustomCyberwares);
+        return response;
+    }
 //
 //    // Pobierz cyberware po id
 //    public Map<String, Object> getCyberwareById(Long cyberwareId) {

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresService.java
@@ -1,14 +1,19 @@
 package dev.goral.rpgmanager.rpgSystems.cpRed.custom.customCyberwares;
 
+import dev.goral.rpgmanager.game.Game;
 import dev.goral.rpgmanager.game.GameRepository;
+import dev.goral.rpgmanager.game.gameUsers.GameUsers;
 import dev.goral.rpgmanager.game.gameUsers.GameUsersRepository;
 import dev.goral.rpgmanager.rpgSystems.cpRed.custom.customArmors.CpRedCustomArmors;
 import dev.goral.rpgmanager.rpgSystems.cpRed.custom.customArmors.CpRedCustomArmorsService;
 import dev.goral.rpgmanager.rpgSystems.cpRed.custom.customCriticalInjuries.CpRedCustomCriticalInjuries;
 import dev.goral.rpgmanager.security.CustomReturnables;
 import dev.goral.rpgmanager.security.exceptions.ResourceNotFoundException;
+import dev.goral.rpgmanager.user.User;
 import dev.goral.rpgmanager.user.UserRepository;
 import lombok.AllArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
@@ -62,6 +67,35 @@ public class CpRedCustomCyberwaresService {
         return response;
 
     }
+    public Map<String, Object> getCyberwareByGame(Long gameId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
+
+        Game game = gameRepository.findById(gameId)
+                .orElseThrow(() -> new ResourceNotFoundException("Gra o id " + gameId + " nie istnieje."));
+
+        GameUsers gameUsers = gameUsersRepository.findGameUsersByUserIdAndGameId(currentUser.getId(), gameId)
+                .orElseThrow(() -> new ResourceNotFoundException("Nie jesteś graczem wybranej gry."));
+        List<CpRedCustomCyberwaresDTO> allCustomCyberwares=cpRedCustomCyberwaresRepository.findAllByGameId(game).stream()
+                .map(CpRedCustomCyberwares -> new CpRedCustomCyberwaresDTO(
+                        CpRedCustomCyberwares.getGameId().getId(),
+                        CpRedCustomCyberwares.getName(),
+                        CpRedCustomCyberwares.getMountPlace().toString(),
+                        CpRedCustomCyberwares.getRequirements(),
+                        CpRedCustomCyberwares.getHumanityLoss(),
+                        CpRedCustomCyberwares.getSize(),
+                        CpRedCustomCyberwares.getInstallationPlace().toString(),
+                        CpRedCustomCyberwares.getPrice(),
+                        CpRedCustomCyberwares.getAvailability().toString(),
+                        CpRedCustomCyberwares.getDescription()
+                )).toList();
+        Map<String,Object> response= CustomReturnables.getOkResponseMap("Customowe wszczepy do gry zostały pobrane.");
+        response.put("customCyberwares",allCustomCyberwares);
+        return response;
+    }
+
 //
 //    // Doadaj cyberware
 //    public Map<String, Object> addCyberware(CpRedCustomCyberwares cpRedCustomCyberwares) {

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresService.java
@@ -4,6 +4,7 @@ import dev.goral.rpgmanager.game.GameRepository;
 import dev.goral.rpgmanager.game.gameUsers.GameUsersRepository;
 import dev.goral.rpgmanager.rpgSystems.cpRed.custom.customArmors.CpRedCustomArmors;
 import dev.goral.rpgmanager.rpgSystems.cpRed.custom.customArmors.CpRedCustomArmorsService;
+import dev.goral.rpgmanager.rpgSystems.cpRed.custom.customCriticalInjuries.CpRedCustomCriticalInjuries;
 import dev.goral.rpgmanager.security.CustomReturnables;
 import dev.goral.rpgmanager.user.UserRepository;
 import lombok.AllArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Stack;
 
 @Service
 @AllArgsConstructor
@@ -54,8 +56,11 @@ public class CpRedCustomCyberwaresService {
 //
 //    }
 //
-//    // Pobierz wszystkie cyberware dla admina
-//    public Map<String, Object> getAllCyberwareForAdmin() {
-//
-//    }
+    // Pobierz wszystkie cyberware dla admina
+    public Map<String, Object> getAllCyberwareForAdmin() {
+        List<CpRedCustomCyberwares> allCustomCyberwaresList = cpRedCustomCyberwaresRepository.findAll();
+        Map<String,Object> response= CustomReturnables.getOkResponseMap("Customowe wszczepy zostały pobrane dla administratora.");
+        response.put("customCyberwares",allCustomCyberwaresList);
+        return response;
+    }
 }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresService.java
@@ -121,7 +121,10 @@ public class CpRedCustomCyberwaresService {
                 .orElseThrow(() -> new ResourceNotFoundException("Nie należysz do podanej gry."));
 
         if (gameUsers.getRole() != GameUsersRole.GAMEMASTER) {
-            throw new IllegalStateException("Tylko GM może dodać pancerz do gry.");
+            throw new IllegalStateException("Tylko GM może dodać wszczep do gry.");
+        }
+        if (game.getStatus() != GameStatus.ACTIVE) {
+            throw new IllegalStateException("Gra o id " + cpRedCustomCyberwares.getGameId() + " nie jest aktywna.");
         }
         if (cpRedCustomCyberwaresRepository.existsByNameAndGameId(cpRedCustomCyberwares.getName(), game)) {
             throw new IllegalStateException("Customowy wszczep o tej nazwie już istnieje.");

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresService.java
@@ -6,6 +6,7 @@ import dev.goral.rpgmanager.rpgSystems.cpRed.custom.customArmors.CpRedCustomArmo
 import dev.goral.rpgmanager.rpgSystems.cpRed.custom.customArmors.CpRedCustomArmorsService;
 import dev.goral.rpgmanager.rpgSystems.cpRed.custom.customCriticalInjuries.CpRedCustomCriticalInjuries;
 import dev.goral.rpgmanager.security.CustomReturnables;
+import dev.goral.rpgmanager.security.exceptions.ResourceNotFoundException;
 import dev.goral.rpgmanager.user.UserRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -40,11 +41,27 @@ public class CpRedCustomCyberwaresService {
         response.put("customCyberwares",allCustomCyberwares);
         return response;
     }
-//
-//    // Pobierz cyberware po id
-//    public Map<String, Object> getCyberwareById(Long cyberwareId) {
-//
-//    }
+
+
+    public Map<String, Object> getCyberwareById(Long cyberwareId) {
+        CpRedCustomCyberwaresDTO customCyberware = cpRedCustomCyberwaresRepository.findById(cyberwareId)
+                .map(CpRedCustomCyberwares -> new CpRedCustomCyberwaresDTO(
+                        CpRedCustomCyberwares.getGameId().getId(),
+                        CpRedCustomCyberwares.getName(),
+                        CpRedCustomCyberwares.getMountPlace().toString(),
+                        CpRedCustomCyberwares.getRequirements(),
+                        CpRedCustomCyberwares.getHumanityLoss(),
+                        CpRedCustomCyberwares.getSize(),
+                        CpRedCustomCyberwares.getInstallationPlace().toString(),
+                        CpRedCustomCyberwares.getPrice(),
+                        CpRedCustomCyberwares.getAvailability().toString(),
+                        CpRedCustomCyberwares.getDescription()
+                )).orElseThrow(()-> new ResourceNotFoundException("Customowy wszczep o id " + cyberwareId + " nie istnieje."));
+        Map<String,Object> response = CustomReturnables.getOkResponseMap("Customowy wszczep został pobran.");
+        response.put("customCyberware", customCyberware);
+        return response;
+
+    }
 //
 //    // Doadaj cyberware
 //    public Map<String, Object> addCyberware(CpRedCustomCyberwares cpRedCustomCyberwares) {


### PR DESCRIPTION
Dodałem wszystkie endpointy do klasy customowych wszczepów.

Funkcjonalności:

-     możliwość tworzenia nowych wszczepów (GM)
-     edycja aktualnych wszczepów (GM)
-     przegląd wszystkich zapisanych wszczepów (wszyscy)
-     możliwość wyszukania wszczepów po ID (wszyscy)
-     przegląd wszystkich zapisanych wszczepów po ID gry (wszyscy gracze konkretnej gry)
-     funkcja zwrotu wszystkich wszczepów w formie obiektów klasy (Admin)

Testowanie:

-     Zaloguj się jako User 1 (GM)
-     Stwórz nową grę
-     Stwórz nowy wszczep
-     Wyświetl wszystkie wszczepy
-     Wyświetl wszczep po ID
-     Wyświetl wszczepy po ID gry
-     Zmodyfikuj wszczep
-     Wyloguj się
-     Zaloguj się jako Admin
-     Wyświetl wszczepy w formie obiektu

Wszystkie endpointy są w jetcliencie. Cała klasa opiera się o erd.