### PR TITLE
Bug przypisanie innego gameId do customowego obiektu

### DIFF
--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -855,14 +855,14 @@
                                       <requestState>
                                         <option name="body">
                                           <bodyState>
-                                            <option name="raw" value="{&#10;  name: &quot;Amunicja EMP zmodyfikowany 3&quot;,&#10;  description: &quot;Amunicja EMP, która wyłącza elektronikę w pojazdach i broniach.&quot;,&#10;  pricePerBullet: 2000,&#10;  availability: &quot;COSTLY&quot;&#10;}" />
+                                            <option name="raw" value="{&#10;  gameId: 1,&#10;  name: &quot;Amunicja EMP zmodyfikowany 3&quot;,&#10;  description: &quot;Amunicja EMP, która wyłącza elektronikę w pojazdach i broniach.&quot;,&#10;  pricePerBullet: 2000,&#10;  availability: &quot;COSTLY&quot;&#10;}" />
                                             <option name="type" value="JSON" />
                                           </bodyState>
                                         </option>
                                         <option name="description" value="Modyfikuje podane paramtery customowej broni" />
                                         <option name="id" value="bb5b8140-83a8-4931-9e9a-1acebee99066" />
                                         <option name="method" value="PUT" />
-                                        <option name="name" value="Modyfikuj customową broń" />
+                                        <option name="name" value="Modyfikuj customową amunicję" />
                                         <option name="sortWeight" value="1500000" />
                                         <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/customAmmunition/update/1" />
                                       </requestState>
@@ -993,7 +993,7 @@
                                       <requestState>
                                         <option name="body">
                                           <bodyState>
-                                            <option name="raw" value="{&#10;  requiredSkillId: 2,&#10;  name: &quot;zmodyfikoany test weapon&quot;,&#10;  type: &quot;ROCKET_LAUNCHER&quot;,&#10;  damage: 4,&#10;  magazineCapacity: 2,&#10;  numberOfAttacks: 1,&#10;  handType: 3,&#10;  quality: &quot;EXCELLENT&quot;,&#10;  price: 20000,&#10;  availability: &quot;SUPER_LUXURY&quot;,&#10;  description: &quot;Jakiś jeszcze piękniejszy opis&quot;&#10;}" />
+                                            <option name="raw" value="{&#10;  gameId: 1,&#10;  requiredSkillId: 2,&#10;  name: &quot;zmodyfikoany test weapon&quot;,&#10;  type: &quot;ROCKET_LAUNCHER&quot;,&#10;  damage: 4,&#10;  magazineCapacity: 2,&#10;  numberOfAttacks: 1,&#10;  handType: 3,&#10;  quality: &quot;EXCELLENT&quot;,&#10;  price: 20000,&#10;  availability: &quot;SUPER_LUXURY&quot;,&#10;  description: &quot;Jakiś jeszcze piękniejszy opis&quot;&#10;}" />
                                             <option name="type" value="JSON" />
                                           </bodyState>
                                         </option>

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customAmmunition/CpRedCustomAmmunitionService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customAmmunition/CpRedCustomAmmunitionService.java
@@ -180,6 +180,10 @@ public class CpRedCustomAmmunitionService {
             throw new IllegalStateException("Gra o id " + ammunitionToUpdate.getGameId().getId() + " nie jest aktywna.");
         }
 
+        if (ammunitionToUpdate.getGameId().getId() != cpRedCustomAmmunition.getGameId()) {
+            throw new IllegalStateException("Nie można zmienić gry dla amunicji.");
+        }
+
         // Sprawdź, czy użytkownik należy do tej gry
         GameUsers gameUsers = gameUsersRepository.findGameUsersByUserIdAndGameId(currentUser.getId(), ammunitionToUpdate.getGameId().getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Nie należysz do podanej gry."));
@@ -187,10 +191,6 @@ public class CpRedCustomAmmunitionService {
         // Sprawdź, czy użytkownik jest GM
         if (gameUsers.getRole() != GameUsersRole.GAMEMASTER) {
             throw new IllegalStateException("Tylko GM może modyfikować amunicję.");
-        }
-
-        if (ammunitionToUpdate.getGameId().getId() != cpRedCustomAmmunition.getGameId()) {
-            throw new IllegalStateException("Nie można zmienić gry dla amunicji.");
         }
 
         // Sprawdź nazwę

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customAmmunition/CpRedCustomAmmunitionService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customAmmunition/CpRedCustomAmmunitionService.java
@@ -189,6 +189,10 @@ public class CpRedCustomAmmunitionService {
             throw new IllegalStateException("Tylko GM może modyfikować amunicję.");
         }
 
+        if (ammunitionToUpdate.getGameId().getId() != cpRedCustomAmmunition.getGameId()) {
+            throw new IllegalStateException("Nie można zmienić gry dla amunicji.");
+        }
+
         // Sprawdź nazwę
         if(cpRedCustomAmmunition.getName() != null) {
             // Sprawdzenie, czy amunicja o podanej nazwie już istnieje

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customArmors/CpRedCustomArmorsService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customArmors/CpRedCustomArmorsService.java
@@ -192,6 +192,10 @@ public class CpRedCustomArmorsService {
             throw new IllegalStateException("Tylko GM może modyfikować pancerz.");
         }
 
+        if (armorToUpdate.getGameId().getId() != cpRedCustomArmors.getGameId()) {
+            throw new IllegalStateException("Nie można zmienić gry dla pancerza.");
+        }
+
         if(cpRedCustomArmors.getName() != null) {
             if (cpRedCustomArmorsRepository.existsByNameAndGameId(cpRedCustomArmors.getName(), armorToUpdate.getGameId())) {
                 throw new IllegalStateException("Customowy pancerz o tej nazwie już istnieje.");

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customArmors/CpRedCustomArmorsService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customArmors/CpRedCustomArmorsService.java
@@ -185,15 +185,15 @@ public class CpRedCustomArmorsService {
             throw new IllegalStateException("Gra o id " + armorToUpdate.getGameId().getId() + " nie jest aktywna.");
         }
 
+        if (armorToUpdate.getGameId().getId() != cpRedCustomArmors.getGameId()) {
+            throw new IllegalStateException("Nie można zmienić gry dla pancerza.");
+        }
+
         GameUsers gameUsers = gameUsersRepository.findGameUsersByUserIdAndGameId(currentUser.getId(), armorToUpdate.getGameId().getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Nie należysz do podanej gry."));
 
         if (gameUsers.getRole() != GameUsersRole.GAMEMASTER) {
             throw new IllegalStateException("Tylko GM może modyfikować pancerz.");
-        }
-
-        if (armorToUpdate.getGameId().getId() != cpRedCustomArmors.getGameId()) {
-            throw new IllegalStateException("Nie można zmienić gry dla pancerza.");
         }
 
         if(cpRedCustomArmors.getName() != null) {

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesService.java
@@ -171,17 +171,16 @@ public class CpRedCustomCriticalInjuriesService {
             throw new IllegalStateException("Gra o id " + injuryToUpdate.getGameId().getId() + " nie jest aktywna.");
         }
 
+        if (injuryToUpdate.getGameId().getId() != cpRedCustomCriticalInjuries.getGameId()) {
+            throw new IllegalStateException("Nie można zmienić gry dla rany krytycznej.");
+        }
+
         GameUsers gameUsers = gameUsersRepository.findGameUsersByUserIdAndGameId(currentUser.getId(), injuryToUpdate.getGameId().getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Nie należysz do podanej gry."));
 
         if (gameUsers.getRole() != GameUsersRole.GAMEMASTER) {
             throw new IllegalStateException("Tylko GM może modyfikować pancerz.");
         }
-
-        if (injuryToUpdate.getGameId().getId() != cpRedCustomCriticalInjuries.getGameId()) {
-            throw new IllegalStateException("Nie można zmienić gry dla rany krytycznej.");
-        }
-
 
         if (cpRedCustomCriticalInjuries.getInjuryPlace() != null) {
             injuryToUpdate.setInjuryPlace(cpRedCustomCriticalInjuries.getInjuryPlace());

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCriticalInjuries/CpRedCustomCriticalInjuriesService.java
@@ -178,6 +178,11 @@ public class CpRedCustomCriticalInjuriesService {
             throw new IllegalStateException("Tylko GM może modyfikować pancerz.");
         }
 
+        if (injuryToUpdate.getGameId().getId() != cpRedCustomCriticalInjuries.getGameId()) {
+            throw new IllegalStateException("Nie można zmienić gry dla rany krytycznej.");
+        }
+
+
         if (cpRedCustomCriticalInjuries.getInjuryPlace() != null) {
             injuryToUpdate.setInjuryPlace(cpRedCustomCriticalInjuries.getInjuryPlace());
         }

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresService.java
@@ -202,6 +202,11 @@ public class CpRedCustomCyberwaresService {
             if (cpRedCustomCyberwaresRepository.existsByNameAndGameId(cpRedCustomCyberwares.getName(), game)) {
                 throw new IllegalStateException("Customowy wszczep o tej nazwie już istnieje.");
             }
+
+            if (cyberwareToUpdate.getGameId().getId() != cpRedCustomCyberwares.getGameId()) {
+                throw new IllegalStateException("Nie można zmienić gry dla wszczepu.");
+            }
+
             if (cpRedCustomCyberwares.getName().isEmpty() ||
                     cpRedCustomCyberwares.getName().trim().isEmpty()) {
                 throw new IllegalStateException("Nazwa wszczepu nie może być pusta.");

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customCyberwares/CpRedCustomCyberwaresService.java
@@ -193,6 +193,11 @@ public class CpRedCustomCyberwaresService {
         if (game.getStatus() != GameStatus.ACTIVE) {
             throw new IllegalStateException("Gra o id " + cyberwareToUpdate.getGameId().getId() + " nie jest aktywna.");
         }
+
+        if (cyberwareToUpdate.getGameId().getId() != cpRedCustomCyberwares.getGameId()) {
+            throw new IllegalStateException("Nie można zmienić gry dla wszczepu.");
+        }
+
         GameUsers gameUsers = gameUsersRepository.findGameUsersByUserIdAndGameId(currentUser.getId(), cyberwareToUpdate.getGameId().getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Nie należysz do podanej gry."));
         if (gameUsers.getRole() != GameUsersRole.GAMEMASTER) {
@@ -203,9 +208,7 @@ public class CpRedCustomCyberwaresService {
                 throw new IllegalStateException("Customowy wszczep o tej nazwie już istnieje.");
             }
 
-            if (cyberwareToUpdate.getGameId().getId() != cpRedCustomCyberwares.getGameId()) {
-                throw new IllegalStateException("Nie można zmienić gry dla wszczepu.");
-            }
+
 
             if (cpRedCustomCyberwares.getName().isEmpty() ||
                     cpRedCustomCyberwares.getName().trim().isEmpty()) {

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customEquipments/CpRedCustomEquipmentsService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customEquipments/CpRedCustomEquipmentsService.java
@@ -154,6 +154,11 @@ public class CpRedCustomEquipmentsService {
         if (gameUsers.getRole() != GameUsersRole.GAMEMASTER) {
             throw new IllegalStateException("Tylko GM może edytować wyposażenie w grze.");
         }
+
+        if (equipmentToUpdate.getGameId().getId() != cpRedCustomEquipments.getGameId()) {
+            throw new IllegalStateException("Nie można zmienić gry dla wyposażenia.");
+        }
+
         if (cpRedCustomEquipments.getName() != null) {
             if (cpRedCustomEquipmentsRepository.existsByNameAndGameId(cpRedCustomEquipments.getName(), game)) {
                 throw new IllegalStateException("Customowy wyposażenie o tej nazwie już istnieje.");

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customEquipments/CpRedCustomEquipmentsService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customEquipments/CpRedCustomEquipmentsService.java
@@ -149,15 +149,18 @@ public class CpRedCustomEquipmentsService {
         if (game.getStatus() != GameStatus.ACTIVE) {
             throw new IllegalStateException("Gra o id " + equipmentToUpdate.getGameId().getId() + " nie jest aktywna.");
         }
+
+        if (equipmentToUpdate.getGameId().getId() != cpRedCustomEquipments.getGameId()) {
+            throw new IllegalStateException("Nie można zmienić gry dla wyposażenia.");
+        }
+
         GameUsers gameUsers = gameUsersRepository.findGameUsersByUserIdAndGameId(currentUser.getId(), equipmentToUpdate.getGameId().getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Nie należysz do podanej gry."));
         if (gameUsers.getRole() != GameUsersRole.GAMEMASTER) {
             throw new IllegalStateException("Tylko GM może edytować wyposażenie w grze.");
         }
 
-        if (equipmentToUpdate.getGameId().getId() != cpRedCustomEquipments.getGameId()) {
-            throw new IllegalStateException("Nie można zmienić gry dla wyposażenia.");
-        }
+
 
         if (cpRedCustomEquipments.getName() != null) {
             if (cpRedCustomEquipmentsRepository.existsByNameAndGameId(cpRedCustomEquipments.getName(), game)) {

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customWeapons/CpRedCustomWeaponsService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customWeapons/CpRedCustomWeaponsService.java
@@ -279,6 +279,10 @@ public class CpRedCustomWeaponsService {
             throw new IllegalStateException("Gra o id " + weaponToUpdate.getGameId().getId() + " nie jest aktywna.");
         }
 
+        if (weaponToUpdate.getGameId().getId() != cpRedCustomWeapon.getGameId()) {
+            throw new IllegalStateException("Nie można zmienić gry dla broni.");
+        }
+
         // Sprawdź, czy użytkownik należy do gry
         GameUsers gameUsers = gameUsersRepository.findGameUsersByUserIdAndGameId(currentUser.getId(), weaponToUpdate.getGameId().getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Nie należysz do podanej gry."));
@@ -286,10 +290,6 @@ public class CpRedCustomWeaponsService {
         // Sprawdź, czy użytkownik jest GM
         if (gameUsers.getRole() != GameUsersRole.GAMEMASTER) {
             throw new IllegalStateException("Tylko GM może modyfikować customową broń.");
-        }
-
-        if (weaponToUpdate.getGameId().getId() != cpRedCustomWeapon.getGameId()) {
-            throw new IllegalStateException("Nie można zmienić gry dla broni.");
         }
 
         // Sprawdź przypisaną statystykę

--- a/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customWeapons/CpRedCustomWeaponsService.java
+++ b/src/main/java/dev/goral/rpgmanager/rpgSystems/cpRed/custom/customWeapons/CpRedCustomWeaponsService.java
@@ -288,6 +288,10 @@ public class CpRedCustomWeaponsService {
             throw new IllegalStateException("Tylko GM może modyfikować customową broń.");
         }
 
+        if (weaponToUpdate.getGameId().getId() != cpRedCustomWeapon.getGameId()) {
+            throw new IllegalStateException("Nie można zmienić gry dla broni.");
+        }
+
         // Sprawdź przypisaną statystykę
         if (cpRedCustomWeapon.getRequiredSkillId() != -1) {
             CpRedSkills requiredSkill = cpRedSkillsRepository.findById(cpRedCustomWeapon.getRequiredSkillId())


### PR DESCRIPTION
Naprawiłem bug związany modyfikacją obiektu ze wszystkich customowych klas.

Funkcjonalności:

-     W przypadku próby zmiany gameId dostajemy informację, że jest to niemożliwe.

Testowanie:

-     Zaloguj się jako User 1 (GM)
-     Stwórz nową grę
-     Stwórz 2 nową grę
-     Stwórz nowy customowy obiekt
-     Zmodyfikuj customowy projekt z gameId != 1 && gameId != 2
-     Zmodyfikuj customowy projekt z gameId == 2
Wszystkie endpointy są w jetcliencie, trzeba tylko zmieniać w body jsona gameId (aktualnie jest 1). Cała klasa opiera się o erd.