### PR TITLE
Cp red character other info

### DIFF
--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -1678,6 +1678,83 @@
                                   </option>
                                   <option name="sortWeight" value="1000000" />
                                 </folderState>
+                                <folderState>
+                                  <option name="id" value="89626b62-8be8-47ab-8fa6-696c19b51ad9" />
+                                  <option name="name" value="OtherInfo" />
+                                  <option name="requests">
+                                    <list>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  &quot;characterId&quot;: 1,&#10;  &quot;notes&quot;: &quot;This is a test character.&quot;,&#10;  &quot;addictions&quot;: &quot;Drugs&quot;,&#10;  &quot;reputation&quot;: &quot;Hero&quot;,&#10;  &quot;style&quot;: &quot;Stealth&quot;,&#10;  &quot;classLifePath&quot;: &quot;Worrior&quot;,&#10;  &quot;accommodation&quot;: &quot;Apartment&quot;,&#10;  &quot;rental&quot;: &quot;500&quot;,&#10;  &quot;livingStandard&quot;: &quot;High&quot;&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Tworzy info przypisane do konkretnej karty postaci" />
+                                        <option name="id" value="7156c912-c1dc-41ce-aa4d-96244489f4cd" />
+                                        <option name="method" value="POST" />
+                                        <option name="name" value="Stwórz info" />
+                                        <option name="sortWeight" value="1000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/OtherInfo/add" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Usuwa info przypisane do konkretnej karty postaci" />
+                                        <option name="id" value="2889f1c0-7992-46ae-aebb-2bf5119c4965" />
+                                        <option name="method" value="DELETE" />
+                                        <option name="name" value="Usuń info" />
+                                        <option name="sortWeight" value="2000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/OtherInfo/delete/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca każde info z każdej karty postaci" />
+                                        <option name="id" value="295b8556-564f-4020-bd14-1f4b61d0540d" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Zwróć wszystkie info" />
+                                        <option name="sortWeight" value="3000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/OtherInfo/all" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca info po unikalnym id" />
+                                        <option name="id" value="e87c6455-a946-4beb-8130-1545f9b48fae" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Zwróć info po id" />
+                                        <option name="sortWeight" value="4000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/OtherInfo/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca obiekty" />
+                                        <option name="id" value="139f0a9e-9b2f-4096-80b3-089465dab4c0" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Zwróć wszystkie info dla Admina" />
+                                        <option name="sortWeight" value="5000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/character/OtherInfo/all" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca wszystkie info z konkretnej karty postaci" />
+                                        <option name="id" value="5f6585ec-5fc6-4f6f-bb38-59734de241d4" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Zwróć info po characterId" />
+                                        <option name="sortWeight" value="6000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/OtherInfo/character/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  &quot;characterId&quot;: 1,&#10;  &quot;notes&quot;: &quot;This is a new test character.&quot;,&#10;  &quot;addictions&quot;: &quot;Drugs and Alcohol&quot;,&#10;  &quot;reputation&quot;: &quot;Drug Dealer&quot;,&#10;  &quot;style&quot;: &quot;Fast&quot;,&#10;  &quot;classLifePath&quot;: &quot;Homeless&quot;,&#10;  &quot;accommodation&quot;: &quot;Tent&quot;,&#10;  &quot;rental&quot;: &quot;600&quot;,&#10;  &quot;livingStandard&quot;: &quot;Low&quot;&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Zmień dane  w info" />
+                                        <option name="id" value="5165a1fe-56da-4a19-9215-6762d11c33c3" />
+                                        <option name="method" value="PUT" />
+                                        <option name="name" value="Modyfikuj info" />
+                                        <option name="sortWeight" value="7000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/OtherInfo/update/1" />
+                                      </requestState>
+                                    </list>
+                                  </option>
+                                  <option name="sortWeight" value="2000000" />
+                                </folderState>
                               </list>
                             </option>
                             <option name="id" value="8a34e9df-ba8d-4e2d-a5d3-98775455502f" />

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfo.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfo.java
@@ -36,6 +36,6 @@ public class CpRedCharacterOtherInfo {
     private String style;
     private String classLifePath;
     private String accommodation;
-    private int rental;
+    private int rental=-1;
     private String livingStandard;
 }

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoController.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoController.java
@@ -1,0 +1,50 @@
+package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterOtherInfo;
+
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping(path = "api/v1/authorized")
+@AllArgsConstructor
+public class CpRedCharacterOtherInfoController {
+    private final CpRedCharacterOtherInfoService cpRedCharacterOtherInfoService;
+
+
+    @GetMapping(path = "/rpgSystems/cpRed/character/OtherInfo/all")
+    public Map<String, Object> getAllOtherInfo() {
+        return cpRedCharacterOtherInfoService.getAllOtherInfo();
+    }
+
+    @GetMapping(path = "/rpgSystems/cpRed/character/OtherInfo/{infoId}")
+    public Map<String, Object> getOtherInfoById(@PathVariable("infoId") Long infoId) {
+        return cpRedCharacterOtherInfoService.getOtherInfoById(infoId);
+    }
+
+    @GetMapping(path = "/rpgSystems/cpRed/character/OtherInfo/character/{characterId}")
+    public Map<String, Object> getOtherInfoByCharacterId(@PathVariable("characterId") Long characterId) {
+        return cpRedCharacterOtherInfoService.getOtherInfoByCharacterId(characterId);
+    }
+
+    @GetMapping(path = "/admin/rpgSystems/cpRed/character/OtherInfo/all")
+    public Map<String, Object> getAllOtherInfoForAdmin() {
+        return cpRedCharacterOtherInfoService.getAllOtherInfoForAdmin();
+    }
+
+    @PostMapping(path = "/rpgSystems/cpRed/character/OtherInfo/add")
+    public Map<String, Object> addOtherInfo(@RequestBody CpRedCharacterOtherInfoRequest cpRedCharacterOtherInfo) {
+        return cpRedCharacterOtherInfoService.addOtherInfo(cpRedCharacterOtherInfo);
+    }
+
+    @DeleteMapping(path = "/rpgSystems/cpRed/character/OtherInfo/delete/{OtherInfoId}")
+    public Map<String, Object> deleteOtherInfo(@PathVariable("infoId") Long infoId) {
+        return cpRedCharacterOtherInfoService.deleteOtherInfo(infoId);
+    }
+
+    @PutMapping(path = "/rpgSystems/cpRed/character/OtherInfo/update/{infoId}")
+    public Map<String, Object> updateOtherInfo(@PathVariable("infoId") Long infoId,
+                                               @RequestBody CpRedCharacterOtherInfoRequest cpRedCharacterOtherInfo) {
+        return cpRedCharacterOtherInfoService.updateOtherInfo(infoId, cpRedCharacterOtherInfo);
+    }
+}

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoController.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoController.java
@@ -37,7 +37,7 @@ public class CpRedCharacterOtherInfoController {
         return cpRedCharacterOtherInfoService.addOtherInfo(cpRedCharacterOtherInfo);
     }
 
-    @DeleteMapping(path = "/rpgSystems/cpRed/character/OtherInfo/delete/{OtherInfoId}")
+    @DeleteMapping(path = "/rpgSystems/cpRed/character/OtherInfo/delete/{infoId}")
     public Map<String, Object> deleteOtherInfo(@PathVariable("infoId") Long infoId) {
         return cpRedCharacterOtherInfoService.deleteOtherInfo(infoId);
     }

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoRepository.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoRepository.java
@@ -1,8 +1,14 @@
 package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterOtherInfo;
 
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharacters;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterEnemies.CpRedCharacterEnemies;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CpRedCharacterOtherInfoRepository extends JpaRepository<CpRedCharacterOtherInfo, Long> {
+    List<CpRedCharacterOtherInfo> findAllByCharacterId_Id(Long characterId);
+    Boolean existsByCharacterId(CpRedCharacters character);
 }

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoRequest.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoRequest.java
@@ -2,12 +2,14 @@ package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterOtherInfo;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
+@NoArgsConstructor
 @AllArgsConstructor
-@ToString
-public class CpRedCharacterOtherInfoDTO {
+public class CpRedCharacterOtherInfoRequest {
     private Long characterId;
     private String notes;
     private String addictions;

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoService.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoService.java
@@ -1,0 +1,360 @@
+package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterOtherInfo;
+
+
+
+import dev.goral.rpghandyhelper.game.Game;
+import dev.goral.rpghandyhelper.game.GameStatus;
+import dev.goral.rpghandyhelper.game.gameUsers.GameUsers;
+import dev.goral.rpghandyhelper.game.gameUsers.GameUsersRepository;
+import dev.goral.rpghandyhelper.game.gameUsers.GameUsersRole;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharacters;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharactersRepository;
+import dev.goral.rpghandyhelper.security.CustomReturnables;
+import dev.goral.rpghandyhelper.security.exceptions.ResourceNotFoundException;
+import dev.goral.rpghandyhelper.user.User;
+import dev.goral.rpghandyhelper.user.UserRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@AllArgsConstructor
+public class CpRedCharacterOtherInfoService {
+    private final CpRedCharacterOtherInfoRepository CpRedCharacterOtherInfoRepository;
+    private final UserRepository userRepository;
+    private final CpRedCharactersRepository cpRedCharactersRepository;
+    private  final GameUsersRepository gameUsersRepository;
+    private final CpRedCharacterOtherInfoRepository cpRedCharacterOtherInfoRepository;
+
+
+    public Map<String, Object> getAllOtherInfo() {
+        List<CpRedCharacterOtherInfo> OtherInfo = CpRedCharacterOtherInfoRepository.findAll();
+        List<CpRedCharacterOtherInfoDTO> OtherInfoDTO = OtherInfo.stream().map(info ->
+                new CpRedCharacterOtherInfoDTO(
+                        info.getCharacterId().getId(),
+                        info.getNotes(),
+                        info.getAddictions(),
+                        info.getReputation(),
+                        info.getStyle(),
+                        info.getClassLifePath(),
+                        info.getAccommodation(),
+                        info.getRental(),
+                        info.getLivingStandard()
+                )).toList();
+        if (OtherInfoDTO.isEmpty()) {
+            return CustomReturnables.getOkResponseMap("Brak dodatkowych informacji dla tej postaci.");
+        }
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano wszystkie dodatkowe informację dla tej postaci.");
+        response.put("OtherInfo", OtherInfoDTO);
+        return response;
+    }
+
+    public  Map<String, Object> getOtherInfoById(Long infoId) {
+        CpRedCharacterOtherInfoDTO info = CpRedCharacterOtherInfoRepository.findById(infoId)
+                .map(cpRedCharacterOtherInfo -> new CpRedCharacterOtherInfoDTO(
+                        cpRedCharacterOtherInfo.getCharacterId().getId(),
+                        cpRedCharacterOtherInfo.getNotes(),
+                        cpRedCharacterOtherInfo.getAddictions(),
+                        cpRedCharacterOtherInfo.getReputation(),
+                        cpRedCharacterOtherInfo.getStyle(),
+                        cpRedCharacterOtherInfo.getClassLifePath(),
+                        cpRedCharacterOtherInfo.getAccommodation(),
+                        cpRedCharacterOtherInfo.getRental(),
+                        cpRedCharacterOtherInfo.getLivingStandard()
+                )).orElseThrow(() -> new ResourceNotFoundException("Dodatkowe Informacje o id " + infoId + " nie zostały znalezione"));
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano dodatkowe informacje dla tej postaci.");
+        response.put("otherInfo", info);
+        return response;
+    }
+
+    public Map<String, Object> getOtherInfoByCharacterId(Long characterId) {
+        List<CpRedCharacterOtherInfo> OtherInfo = CpRedCharacterOtherInfoRepository.findAllByCharacterId_Id(characterId);
+        if (OtherInfo.isEmpty()) {
+            return CustomReturnables.getOkResponseMap("Brak dodatkowych informacji dla postaci o id " + characterId);
+        }
+        List<CpRedCharacterOtherInfoDTO> OtherInfoDTO = OtherInfo.stream().map(info ->
+                new CpRedCharacterOtherInfoDTO(
+                        info.getCharacterId().getId(),
+                        info.getNotes(),
+                        info.getAddictions(),
+                        info.getReputation(),
+                        info.getStyle(),
+                        info.getClassLifePath(),
+                        info.getAccommodation(),
+                        info.getRental(),
+                        info.getLivingStandard()
+                )).toList();
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano dodatkowe informacje dla postaci o id " + characterId);
+        response.put("OtherInfo", OtherInfoDTO);
+        return response;
+    }
+
+    public Map<String, Object> getAllOtherInfoForAdmin() {
+        List<CpRedCharacterOtherInfo> allOtherInfo = CpRedCharacterOtherInfoRepository.findAll();
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano wszystkie dodatkowe informacje.");
+        response.put("OtherInfo", allOtherInfo);
+        return response;
+    }
+
+    public Map<String,Object> addOtherInfo(CpRedCharacterOtherInfoRequest cpRedCharacterOtherInfo) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
+        if(
+                cpRedCharacterOtherInfo.getNotes() == null ||
+                cpRedCharacterOtherInfo.getAddictions() == null ||
+                cpRedCharacterOtherInfo.getReputation() == null ||
+                cpRedCharacterOtherInfo.getStyle() == null ||
+                cpRedCharacterOtherInfo.getClassLifePath() == null ||
+                cpRedCharacterOtherInfo.getAccommodation() == null ||
+                cpRedCharacterOtherInfo.getRental() == -1 ||
+                cpRedCharacterOtherInfo.getLivingStandard() == null
+        ) {
+            throw new IllegalArgumentException("Wszystkie pola są wymagane.");
+        }
+
+        CpRedCharacters character = cpRedCharactersRepository.findById(cpRedCharacterOtherInfo.getCharacterId())
+                .orElseThrow(() -> new ResourceNotFoundException("Postać o id " + cpRedCharacterOtherInfo.getCharacterId() + " nie została znaleziona"));
+
+        Game game=character.getGame();
+        if (game == null) {
+            throw new ResourceNotFoundException("Gra dla tej postaci nie została znaleziona.");
+        }
+
+        if (game.getStatus()!= GameStatus.ACTIVE) {
+            throw new IllegalStateException("Gra nie jest aktywna.");
+        }
+
+        GameUsers gameUsers = gameUsersRepository.findByGameIdAndUserId(character.getGame().getId(), currentUser.getId());
+        if (gameUsers == null) {
+            throw new ResourceNotFoundException("Nie znaleziono użytkownika w grze.");
+        }
+
+        if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+            if (!character.getUser().getId().equals(currentUser.getId())) {
+                throw new IllegalStateException("Nie masz uprawnień do dodawania dodatkowych infomacji dla tej postaci.");
+            }
+        }
+
+        if( CpRedCharacterOtherInfoRepository.existsByCharacterId(character)) {
+            throw new IllegalArgumentException("Dodatkowe informacje o tej nazwie już istnieją dla tej postaci.");
+        }
+        if(cpRedCharacterOtherInfo.getNotes().isEmpty()||
+                cpRedCharacterOtherInfo.getNotes().trim().isEmpty()){
+            throw new IllegalArgumentException("Notatka nie może być pusta dla tej postaci..");
+        }
+        if(cpRedCharacterOtherInfo.getNotes().length()>500){
+            throw new IllegalArgumentException("Notatka nie może być dłuższa niż 500 znaków dla tej postaci.");
+        }
+        if(cpRedCharacterOtherInfo.getAddictions().length()>255) {
+            throw new IllegalArgumentException("Informacja o uzależnieniu nie może być dłuższa niż 255 znaków dla tej postaci.");
+        }
+        if(cpRedCharacterOtherInfo.getReputation().isEmpty()||
+                cpRedCharacterOtherInfo.getReputation().trim().isEmpty()){
+            throw new IllegalArgumentException("Informacja o reputacji nie może być pusta dla tej postaci.");
+        }
+        if(cpRedCharacterOtherInfo.getReputation().length()>255) {
+            throw new IllegalArgumentException("Informacja o reputacji nie może być dłuższa niż 255 znaków dla tej postaci.");
+        }
+        if(cpRedCharacterOtherInfo.getStyle().isEmpty()||
+                cpRedCharacterOtherInfo.getStyle().trim().isEmpty()){
+            throw new IllegalArgumentException("Informacja o stylu nie może być pusta dla tej postaci.");
+        }
+        if(cpRedCharacterOtherInfo.getStyle().length()>255) {
+            throw new IllegalArgumentException("Informacja o stylu nie może być dłuższa niż 255 znaków dla tej postaci.");
+        }
+        if(cpRedCharacterOtherInfo.getClassLifePath().isEmpty()||
+                cpRedCharacterOtherInfo.getClassLifePath().trim().isEmpty()){
+            throw new IllegalArgumentException("Informacja o ścieżce życiowej nie może być pusta dla tej postaci.");
+        }
+        if(cpRedCharacterOtherInfo.getClassLifePath().length()>255) {
+            throw new IllegalArgumentException("Informacja ścieżce życiowej nie może być dłuższa niż 255 znaków dla tej postaci.");
+        }
+        if(cpRedCharacterOtherInfo.getAccommodation().isEmpty()||
+                cpRedCharacterOtherInfo.getAccommodation().trim().isEmpty()){
+            throw new IllegalArgumentException("Informacja o zakwaterowaniu nie może być pusta dla tej postaci.");
+        }
+        if(cpRedCharacterOtherInfo.getAccommodation().length()>255) {
+            throw new IllegalArgumentException("Informacja o zakwaterowaniu nie może być dłuższa niż 255 znaków dla tej postaci.");
+        }
+
+        if(cpRedCharacterOtherInfo.getRental()<=0){
+            throw new IllegalArgumentException("Wysokość czynszu musi być większa od 0 dla tej postaci.");
+        }
+
+        if(cpRedCharacterOtherInfo.getLivingStandard().isEmpty()||
+                cpRedCharacterOtherInfo.getLivingStandard().trim().isEmpty()){
+            throw new IllegalArgumentException("Informacja o standardzie życia nie może być pusta dla tej postaci.");
+        }
+        if(cpRedCharacterOtherInfo.getLivingStandard().length()>255) {
+            throw new IllegalArgumentException("Informacja o standardzie życia nie może być dłuższa niż 255 znaków dla tej postaci.");
+        }
+
+        CpRedCharacterOtherInfo newInfo = new CpRedCharacterOtherInfo(
+                null,
+                character,
+                cpRedCharacterOtherInfo.getNotes(),
+                cpRedCharacterOtherInfo.getAddictions(),
+                cpRedCharacterOtherInfo.getReputation(),
+                cpRedCharacterOtherInfo.getStyle(),
+                cpRedCharacterOtherInfo.getClassLifePath(),
+                cpRedCharacterOtherInfo.getAccommodation(),
+                cpRedCharacterOtherInfo.getRental(),
+                cpRedCharacterOtherInfo.getLivingStandard()
+        );
+        cpRedCharacterOtherInfoRepository.save(newInfo);
+        return CustomReturnables.getOkResponseMap("Dodatkowe informacje zostały dodane.");
+    }
+    public Map<String, Object> deleteOtherInfo(Long infoId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
+
+        CpRedCharacterOtherInfo info = cpRedCharacterOtherInfoRepository.findById(infoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Dodatkowe informacje o id " + infoId + " nie zostały znalezione"));
+
+        CpRedCharacters character = cpRedCharactersRepository.findById(info.getCharacterId().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Postać o id " + info.getCharacterId().getId() + " nie została znaleziona"));
+
+        Game game=character.getGame();
+        if (game == null) {
+            throw new ResourceNotFoundException("Gra dla tej postaci nie została znaleziona.");
+        }
+
+        if (game.getStatus()!= GameStatus.ACTIVE) {
+            throw new IllegalStateException("Gra nie jest aktywna.");
+        }
+        GameUsers gameUsers = gameUsersRepository.findByUserId(currentUser.getId());
+        if (gameUsers == null) {
+            throw new ResourceNotFoundException("Nie znaleziono użytkownika w grze.");
+        }
+
+        if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+            if (!character.getUser().getId().equals(currentUser.getId())) {
+                throw new IllegalStateException("Nie masz uprawnień do usuwania dodatkowych informacji dla tej postaci.");
+            }
+        }
+        cpRedCharacterOtherInfoRepository.deleteById(infoId);
+        return CustomReturnables.getOkResponseMap("Dodatkowe informacje o id " + infoId + " zostały usunięte.");
+    }
+
+    public Map<String, Object> updateOtherInfo(Long infoId, CpRedCharacterOtherInfoRequest cpRedCharacterOtherInfo) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
+
+        CpRedCharacterOtherInfo infoToUpdate = cpRedCharacterOtherInfoRepository.findById(infoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Dodatkowe informacje o id " + infoId + " nie został znaleziony"));
+
+        CpRedCharacters character = cpRedCharactersRepository.findById(infoToUpdate.getCharacterId().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Postać o id " + infoToUpdate.getCharacterId().getId() + " nie została znaleziona"));
+
+        Game game=character.getGame();
+        if (game == null) {
+            throw new ResourceNotFoundException("Gra dla tej postaci nie została znaleziona.");
+        }
+
+        if (game.getStatus()!= GameStatus.ACTIVE) {
+            throw new IllegalStateException("Gra nie jest aktywna.");
+        }
+
+        GameUsers gameUsers = gameUsersRepository.findByGameIdAndUserId(character.getGame().getId(), currentUser.getId());
+        if (gameUsers == null) {
+            throw new ResourceNotFoundException("Nie znaleziono użytkownika w grze.");
+        }
+
+        if (gameUsers.getRole() != GameUsersRole.GAMEMASTER) {
+            if (!character.getUser().getId().equals(currentUser.getId())) {
+                throw new IllegalStateException("Nie masz uprawnień do modyfikacji dodatkowych informacji dla tej postaci.");
+            }
+        }
+
+        if (infoToUpdate.getCharacterId().getId() != cpRedCharacterOtherInfo.getCharacterId()) {
+            throw new IllegalArgumentException("Nie można zmienić postaci przypisanej do tych dodatkowych informacji.");
+        }
+        if (cpRedCharacterOtherInfoRepository.existsByCharacterId(character)) {
+            throw new IllegalArgumentException("Dodatkowe informacje o tej nazwie już istnieją dla tej postaci.");
+        }
+        if (cpRedCharacterOtherInfo.getNotes() != null) {
+            if (cpRedCharacterOtherInfo.getNotes().isEmpty() ||
+                    cpRedCharacterOtherInfo.getNotes().trim().isEmpty()) {
+                throw new IllegalArgumentException("Notatka nie może być pusta dla tej postaci.");
+            }
+            if (cpRedCharacterOtherInfo.getNotes().length() > 500) {
+                throw new IllegalArgumentException("Notatka nie może być dłuższa niż 500 znaków dla tej postaci.");
+            }
+            infoToUpdate.setNotes(cpRedCharacterOtherInfo.getNotes());
+        }
+        if (cpRedCharacterOtherInfo.getAddictions() != null) {
+            if (cpRedCharacterOtherInfo.getAddictions().length() > 255) {
+                throw new IllegalArgumentException("Informacja o uzależnieniu nie może być dłuższa niż 255 znaków dla tej postaci.");
+            }
+            infoToUpdate.setAddictions(cpRedCharacterOtherInfo.getAddictions());
+        }
+        if( cpRedCharacterOtherInfo.getReputation() != null) {
+            if (cpRedCharacterOtherInfo.getReputation().isEmpty() ||
+                    cpRedCharacterOtherInfo.getReputation().trim().isEmpty()) {
+                throw new IllegalArgumentException("Informacja o reputacji nie może być pusta dla tej postaci.");
+            }
+            if (cpRedCharacterOtherInfo.getReputation().length() > 255) {
+                throw new IllegalArgumentException("Informacja o reputacji nie może być dłuższa niż 255 znaków dla tej postaci.");
+            }
+            infoToUpdate.setReputation(cpRedCharacterOtherInfo.getReputation());
+        }
+        if (cpRedCharacterOtherInfo.getStyle() != null) {
+            if (cpRedCharacterOtherInfo.getStyle().isEmpty() ||
+                    cpRedCharacterOtherInfo.getStyle().trim().isEmpty()) {
+                throw new IllegalArgumentException("Informacja o stylu nie może być pusta dla tej postaci.");
+            }
+            if (cpRedCharacterOtherInfo.getStyle().length() > 255) {
+                throw new IllegalArgumentException("Informacja o stylu nie może być dłuższa niż 255 znaków dla tej postaci.");
+            }
+            infoToUpdate.setStyle(cpRedCharacterOtherInfo.getStyle());
+        }
+        if (cpRedCharacterOtherInfo.getClassLifePath() != null) {
+            if (cpRedCharacterOtherInfo.getClassLifePath().isEmpty() ||
+                    cpRedCharacterOtherInfo.getClassLifePath().trim().isEmpty()) {
+                throw new IllegalArgumentException("Informacja o ścieżce życiowej nie może być pusta dla tej postaci.");
+            }
+            if (cpRedCharacterOtherInfo.getClassLifePath().length() > 255) {
+                throw new IllegalArgumentException("Informacja o ścieżce życiowej nie może być dłuższa niż 255 znaków dla tej postaci.");
+            }
+            infoToUpdate.setClassLifePath(cpRedCharacterOtherInfo.getClassLifePath());
+        }
+        if (cpRedCharacterOtherInfo.getAccommodation() != null) {
+            if (cpRedCharacterOtherInfo.getAccommodation().isEmpty() ||
+                    cpRedCharacterOtherInfo.getAccommodation().trim().isEmpty()) {
+                throw new IllegalArgumentException("Informacja o zakwaterowaniu nie może być pusta dla tej postaci.");
+            }
+            if (cpRedCharacterOtherInfo.getAccommodation().length() > 255) {
+                throw new IllegalArgumentException("Informacja o zakwaterowaniu nie może być dłuższa niż 255 znaków dla tej postaci.");
+            }
+            infoToUpdate.setAccommodation(cpRedCharacterOtherInfo.getAccommodation());
+        }
+        if (cpRedCharacterOtherInfo.getRental() != -1) {
+            if (cpRedCharacterOtherInfo.getRental() <= 0) {
+                throw new IllegalArgumentException("Wysokość czynszu musi być większa od 0 dla tej postaci.");
+            }
+            infoToUpdate.setRental(cpRedCharacterOtherInfo.getRental());
+        }
+        if (cpRedCharacterOtherInfo.getLivingStandard() != null) {
+            if (cpRedCharacterOtherInfo.getLivingStandard().isEmpty() ||
+                    cpRedCharacterOtherInfo.getLivingStandard().trim().isEmpty()) {
+                throw new IllegalArgumentException("Informacja o standardzie życia nie może być pusta dla tej postaci.");
+            }
+            if (cpRedCharacterOtherInfo.getLivingStandard().length() > 255) {
+                throw new IllegalArgumentException("Informacja o standardzie życia nie może być dłuższa niż 255 znaków dla tej postaci.");
+            }
+            infoToUpdate.setLivingStandard(cpRedCharacterOtherInfo.getLivingStandard());
+        }
+        cpRedCharacterOtherInfoRepository.save(infoToUpdate);
+        return CustomReturnables.getOkResponseMap("Dodatkowe informacje zostały zaktualizowane.");
+    }
+}

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoService.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoService.java
@@ -151,36 +151,36 @@ public class CpRedCharacterOtherInfoService {
         if(cpRedCharacterOtherInfo.getNotes().length()>500){
             throw new IllegalArgumentException("Notatka nie może być dłuższa niż 500 znaków dla tej postaci.");
         }
-        if(cpRedCharacterOtherInfo.getAddictions().length()>255) {
-            throw new IllegalArgumentException("Informacja o uzależnieniu nie może być dłuższa niż 255 znaków dla tej postaci.");
+        if(cpRedCharacterOtherInfo.getAddictions().length()>500) {
+            throw new IllegalArgumentException("Informacja o uzależnieniu nie może być dłuższa niż 500 znaków dla tej postaci.");
         }
         if(cpRedCharacterOtherInfo.getReputation().isEmpty()||
                 cpRedCharacterOtherInfo.getReputation().trim().isEmpty()){
             throw new IllegalArgumentException("Informacja o reputacji nie może być pusta dla tej postaci.");
         }
-        if(cpRedCharacterOtherInfo.getReputation().length()>255) {
-            throw new IllegalArgumentException("Informacja o reputacji nie może być dłuższa niż 255 znaków dla tej postaci.");
+        if(cpRedCharacterOtherInfo.getReputation().length()>500) {
+            throw new IllegalArgumentException("Informacja o reputacji nie może być dłuższa niż 500 znaków dla tej postaci.");
         }
         if(cpRedCharacterOtherInfo.getStyle().isEmpty()||
                 cpRedCharacterOtherInfo.getStyle().trim().isEmpty()){
             throw new IllegalArgumentException("Informacja o stylu nie może być pusta dla tej postaci.");
         }
-        if(cpRedCharacterOtherInfo.getStyle().length()>255) {
-            throw new IllegalArgumentException("Informacja o stylu nie może być dłuższa niż 255 znaków dla tej postaci.");
+        if(cpRedCharacterOtherInfo.getStyle().length()>500) {
+            throw new IllegalArgumentException("Informacja o stylu nie może być dłuższa niż 500 znaków dla tej postaci.");
         }
         if(cpRedCharacterOtherInfo.getClassLifePath().isEmpty()||
                 cpRedCharacterOtherInfo.getClassLifePath().trim().isEmpty()){
             throw new IllegalArgumentException("Informacja o ścieżce życiowej nie może być pusta dla tej postaci.");
         }
-        if(cpRedCharacterOtherInfo.getClassLifePath().length()>255) {
-            throw new IllegalArgumentException("Informacja ścieżce życiowej nie może być dłuższa niż 255 znaków dla tej postaci.");
+        if(cpRedCharacterOtherInfo.getClassLifePath().length()>500) {
+            throw new IllegalArgumentException("Informacja ścieżce życiowej nie może być dłuższa niż 500 znaków dla tej postaci.");
         }
         if(cpRedCharacterOtherInfo.getAccommodation().isEmpty()||
                 cpRedCharacterOtherInfo.getAccommodation().trim().isEmpty()){
             throw new IllegalArgumentException("Informacja o zakwaterowaniu nie może być pusta dla tej postaci.");
         }
-        if(cpRedCharacterOtherInfo.getAccommodation().length()>255) {
-            throw new IllegalArgumentException("Informacja o zakwaterowaniu nie może być dłuższa niż 255 znaków dla tej postaci.");
+        if(cpRedCharacterOtherInfo.getAccommodation().length()>500) {
+            throw new IllegalArgumentException("Informacja o zakwaterowaniu nie może być dłuższa niż 500 znaków dla tej postaci.");
         }
 
         if(cpRedCharacterOtherInfo.getRental()<=0){
@@ -191,8 +191,8 @@ public class CpRedCharacterOtherInfoService {
                 cpRedCharacterOtherInfo.getLivingStandard().trim().isEmpty()){
             throw new IllegalArgumentException("Informacja o standardzie życia nie może być pusta dla tej postaci.");
         }
-        if(cpRedCharacterOtherInfo.getLivingStandard().length()>255) {
-            throw new IllegalArgumentException("Informacja o standardzie życia nie może być dłuższa niż 255 znaków dla tej postaci.");
+        if(cpRedCharacterOtherInfo.getLivingStandard().length()>500) {
+            throw new IllegalArgumentException("Informacja o standardzie życia nie może być dłuższa niż 500 znaków dla tej postaci.");
         }
 
         CpRedCharacterOtherInfo newInfo = new CpRedCharacterOtherInfo(
@@ -279,9 +279,6 @@ public class CpRedCharacterOtherInfoService {
         if (infoToUpdate.getCharacterId().getId() != cpRedCharacterOtherInfo.getCharacterId()) {
             throw new IllegalArgumentException("Nie można zmienić postaci przypisanej do tych dodatkowych informacji.");
         }
-        if (cpRedCharacterOtherInfoRepository.existsByCharacterId(character)) {
-            throw new IllegalArgumentException("Dodatkowe informacje o tej nazwie już istnieją dla tej postaci.");
-        }
         if (cpRedCharacterOtherInfo.getNotes() != null) {
             if (cpRedCharacterOtherInfo.getNotes().isEmpty() ||
                     cpRedCharacterOtherInfo.getNotes().trim().isEmpty()) {
@@ -293,8 +290,8 @@ public class CpRedCharacterOtherInfoService {
             infoToUpdate.setNotes(cpRedCharacterOtherInfo.getNotes());
         }
         if (cpRedCharacterOtherInfo.getAddictions() != null) {
-            if (cpRedCharacterOtherInfo.getAddictions().length() > 255) {
-                throw new IllegalArgumentException("Informacja o uzależnieniu nie może być dłuższa niż 255 znaków dla tej postaci.");
+            if (cpRedCharacterOtherInfo.getAddictions().length() > 500) {
+                throw new IllegalArgumentException("Informacja o uzależnieniu nie może być dłuższa niż 500 znaków dla tej postaci.");
             }
             infoToUpdate.setAddictions(cpRedCharacterOtherInfo.getAddictions());
         }
@@ -303,8 +300,8 @@ public class CpRedCharacterOtherInfoService {
                     cpRedCharacterOtherInfo.getReputation().trim().isEmpty()) {
                 throw new IllegalArgumentException("Informacja o reputacji nie może być pusta dla tej postaci.");
             }
-            if (cpRedCharacterOtherInfo.getReputation().length() > 255) {
-                throw new IllegalArgumentException("Informacja o reputacji nie może być dłuższa niż 255 znaków dla tej postaci.");
+            if (cpRedCharacterOtherInfo.getReputation().length() > 500) {
+                throw new IllegalArgumentException("Informacja o reputacji nie może być dłuższa niż 500 znaków dla tej postaci.");
             }
             infoToUpdate.setReputation(cpRedCharacterOtherInfo.getReputation());
         }
@@ -313,8 +310,8 @@ public class CpRedCharacterOtherInfoService {
                     cpRedCharacterOtherInfo.getStyle().trim().isEmpty()) {
                 throw new IllegalArgumentException("Informacja o stylu nie może być pusta dla tej postaci.");
             }
-            if (cpRedCharacterOtherInfo.getStyle().length() > 255) {
-                throw new IllegalArgumentException("Informacja o stylu nie może być dłuższa niż 255 znaków dla tej postaci.");
+            if (cpRedCharacterOtherInfo.getStyle().length() > 500) {
+                throw new IllegalArgumentException("Informacja o stylu nie może być dłuższa niż 500 znaków dla tej postaci.");
             }
             infoToUpdate.setStyle(cpRedCharacterOtherInfo.getStyle());
         }
@@ -323,8 +320,8 @@ public class CpRedCharacterOtherInfoService {
                     cpRedCharacterOtherInfo.getClassLifePath().trim().isEmpty()) {
                 throw new IllegalArgumentException("Informacja o ścieżce życiowej nie może być pusta dla tej postaci.");
             }
-            if (cpRedCharacterOtherInfo.getClassLifePath().length() > 255) {
-                throw new IllegalArgumentException("Informacja o ścieżce życiowej nie może być dłuższa niż 255 znaków dla tej postaci.");
+            if (cpRedCharacterOtherInfo.getClassLifePath().length() > 500) {
+                throw new IllegalArgumentException("Informacja o ścieżce życiowej nie może być dłuższa niż 500 znaków dla tej postaci.");
             }
             infoToUpdate.setClassLifePath(cpRedCharacterOtherInfo.getClassLifePath());
         }
@@ -333,8 +330,8 @@ public class CpRedCharacterOtherInfoService {
                     cpRedCharacterOtherInfo.getAccommodation().trim().isEmpty()) {
                 throw new IllegalArgumentException("Informacja o zakwaterowaniu nie może być pusta dla tej postaci.");
             }
-            if (cpRedCharacterOtherInfo.getAccommodation().length() > 255) {
-                throw new IllegalArgumentException("Informacja o zakwaterowaniu nie może być dłuższa niż 255 znaków dla tej postaci.");
+            if (cpRedCharacterOtherInfo.getAccommodation().length() > 500) {
+                throw new IllegalArgumentException("Informacja o zakwaterowaniu nie może być dłuższa niż 500 znaków dla tej postaci.");
             }
             infoToUpdate.setAccommodation(cpRedCharacterOtherInfo.getAccommodation());
         }
@@ -349,8 +346,8 @@ public class CpRedCharacterOtherInfoService {
                     cpRedCharacterOtherInfo.getLivingStandard().trim().isEmpty()) {
                 throw new IllegalArgumentException("Informacja o standardzie życia nie może być pusta dla tej postaci.");
             }
-            if (cpRedCharacterOtherInfo.getLivingStandard().length() > 255) {
-                throw new IllegalArgumentException("Informacja o standardzie życia nie może być dłuższa niż 255 znaków dla tej postaci.");
+            if (cpRedCharacterOtherInfo.getLivingStandard().length() > 500) {
+                throw new IllegalArgumentException("Informacja o standardzie życia nie może być dłuższa niż 500 znaków dla tej postaci.");
             }
             infoToUpdate.setLivingStandard(cpRedCharacterOtherInfo.getLivingStandard());
         }

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoService.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoService.java
@@ -135,7 +135,7 @@ public class CpRedCharacterOtherInfoService {
             throw new ResourceNotFoundException("Nie znaleziono użytkownika w grze.");
         }
 
-        if(character.getUser().getId()==null){
+        if(character.getUser()==null){
             if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
                 throw new IllegalStateException("Nie masz uprawnień do dodawania dodatkowych informacji w dla tej postaci.");
             }
@@ -240,7 +240,7 @@ public class CpRedCharacterOtherInfoService {
             throw new ResourceNotFoundException("Nie znaleziono użytkownika w grze.");
         }
 
-        if(character.getUser().getId()==null){
+        if(character.getUser()==null){
             if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
                 throw new IllegalStateException("Nie masz uprawnień do dodawania dodatkowych informacji w dla tej postaci.");
             }
@@ -280,7 +280,7 @@ public class CpRedCharacterOtherInfoService {
             throw new ResourceNotFoundException("Nie znaleziono użytkownika w grze.");
         }
 
-        if(character.getUser().getId()==null){
+        if(character.getUser()==null){
             if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
                 throw new IllegalStateException("Nie masz uprawnień do dodawania dodatkowych informacji w dla tej postaci.");
             }

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoService.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoService.java
@@ -135,14 +135,19 @@ public class CpRedCharacterOtherInfoService {
             throw new ResourceNotFoundException("Nie znaleziono użytkownika w grze.");
         }
 
-        if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+        if(character.getUser().getId()==null){
+            if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+                throw new IllegalStateException("Nie masz uprawnień do dodawania dodatkowych informacji w dla tej postaci.");
+            }
+        }
+        else if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
             if (!character.getUser().getId().equals(currentUser.getId())) {
-                throw new IllegalStateException("Nie masz uprawnień do dodawania dodatkowych infomacji dla tej postaci.");
+                throw new IllegalStateException("Nie masz uprawnień do dodawania dodatkowych informacji dla tej postaci.");
             }
         }
 
         if( CpRedCharacterOtherInfoRepository.existsByCharacterId(character)) {
-            throw new IllegalArgumentException("Dodatkowe informacje o tej nazwie już istnieją dla tej postaci.");
+            throw new IllegalArgumentException("Dodatkowe informacje już istnieją dla tej postaci.");
         }
         if(cpRedCharacterOtherInfo.getNotes().isEmpty()||
                 cpRedCharacterOtherInfo.getNotes().trim().isEmpty()){
@@ -235,9 +240,14 @@ public class CpRedCharacterOtherInfoService {
             throw new ResourceNotFoundException("Nie znaleziono użytkownika w grze.");
         }
 
-        if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+        if(character.getUser().getId()==null){
+            if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+                throw new IllegalStateException("Nie masz uprawnień do dodawania dodatkowych informacji w dla tej postaci.");
+            }
+        }
+        else if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
             if (!character.getUser().getId().equals(currentUser.getId())) {
-                throw new IllegalStateException("Nie masz uprawnień do usuwania dodatkowych informacji dla tej postaci.");
+                throw new IllegalStateException("Nie masz uprawnień do dodawania dodatkowych informacji dla tej postaci.");
             }
         }
         cpRedCharacterOtherInfoRepository.deleteById(infoId);
@@ -270,9 +280,14 @@ public class CpRedCharacterOtherInfoService {
             throw new ResourceNotFoundException("Nie znaleziono użytkownika w grze.");
         }
 
-        if (gameUsers.getRole() != GameUsersRole.GAMEMASTER) {
+        if(character.getUser().getId()==null){
+            if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+                throw new IllegalStateException("Nie masz uprawnień do dodawania dodatkowych informacji w dla tej postaci.");
+            }
+        }
+        else if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
             if (!character.getUser().getId().equals(currentUser.getId())) {
-                throw new IllegalStateException("Nie masz uprawnień do modyfikacji dodatkowych informacji dla tej postaci.");
+                throw new IllegalStateException("Nie masz uprawnień do dodawania dodatkowych informacji dla tej postaci.");
             }
         }
 


### PR DESCRIPTION
Dodałem wszystkie endpointy do klasy dodatkowych informacji dla karty postaci

Funkcjonalności:

-     możliwość tworzenia dodatkowych informacji (GM lub właściciel karty)
-     edycja aktualnych informacji (GM lub właściciel karty)
-     przegląd wszystkich zapisanych dodatkowych informacji (wszyscy)
-     możliwość wyszukania  dodatkowych informacji po ID (wszyscy)
-     przegląd wszystkich zapisanych  dodatkowych informacji po ID karty postaci (wszyscy)
-     funkcja zwrotu wszystkich dodatkowych informacji formie obiektów klasy (Admin)
-     funkcja usunięcia dodatkowych informacji (GM lub właściciel karty)

Testowanie:

-     Zaloguj się jako User 2 (właściciel karty)
-     Stwórz kartę postaci
-     Stwórz dodatkowe informacje
-     Wyświetl wszystkie dodatkowe informacje
-     Wyświetl dodatkowe informacje po ID
-     Zmodyfikuj dodatkowe informacje
-     Wyloguj się
-     Zaloguj się jako Admin
-     Wyświetl dodatkowe informacje w formie obiektu
-     Zaloguj się jako User 1 (GM)
-     Usuń dodatkowe informacje
-     Wyświetl wroga po ID karty postaci

Wszystkie endpointy są w jetcliencie. Cała klasa opiera się o erd. Z dodatkowych informacji każda karta postaci może mieć tylko jeden obiekt dodatkowych informacji.