### PR TITLE
Cpredcharactersstats

### DIFF
--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -1602,6 +1602,164 @@
                             <option name="folders">
                               <list>
                                 <folderState>
+
+                                  <option name="id" value="28400773-5ea7-486b-a325-1515d79aaf5a" />
+                                  <option name="name" value="Enemies" />
+
+                                  <option name="requests">
+                                    <list>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+
+                                            <option name="raw" value="{&#10;  characterId: 1,&#10;  name: &quot;The worst enemy&quot;,&#10;  whoIs: &quot;The worst enemy&quot;,&#10;  causeOfConflict: &quot;The worst cause of conflict&quot;,&#10;  whatHas: &quot;Nothing&quot;,&#10;  intends: &quot;To destroy everything&quot;,&#10;  description: &quot;A very bad enemy who causes a lot of trouble&quot;&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Tworzy wroga przypisanego do konkretnej karty postaci" />
+                                        <option name="id" value="b20421e4-10e7-4810-a94e-89c37a79ef5d" />
+                                        <option name="method" value="POST" />
+                                        <option name="name" value="Stwórz wroga" />
+                                        <option name="sortWeight" value="1000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/enemies/add" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Usuwa wroga przypisanego do konkretnej karty postaci" />
+                                        <option name="id" value="6be99324-7022-482d-b4d8-880271215069" />
+                                        <option name="method" value="DELETE" />
+                                        <option name="name" value="Usuń wroga" />
+                                        <option name="sortWeight" value="2000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/enemies/delete/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca każdego wroga z każdej karty postaci" />
+                                        <option name="id" value="22d9552e-39b9-482a-a35d-fe31ca9019db" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Zwróć wszystkich wrogów" />
+                                        <option name="sortWeight" value="3000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/enemies/all" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca wroga po unikalnym id" />
+                                        <option name="id" value="fae323dd-c4cc-4e20-b9fb-cb57430a833b" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Zwróć wroga po id" />
+                                        <option name="sortWeight" value="4000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/enemies/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca obiekty" />
+                                        <option name="id" value="c950b47d-99a7-4850-ad7e-45c0ab7705ed" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Zwróć wszystkich wrogów dla Admina" />
+                                        <option name="sortWeight" value="5000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/character/enemies/all" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca wszystkich wrogów z konkretnej karty postaci" />
+                                        <option name="id" value="a7110631-5a0d-4432-8c97-de406eeb2363" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Zwróć wroga po characterId" />
+                                        <option name="sortWeight" value="6000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/enemies/character/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+
+                                            <option name="raw" value="{&#10;  characterId: 1,&#10;  name: &quot;The enemy&quot;,&#10;  whoIs: &quot;Who knows&quot;,&#10;  causeOfConflict: &quot;I don't know&quot;,&#10;  whatHas: &quot;everything&quot;,&#10;  intends: &quot;I don't know&quot;,&#10;  description: &quot;Wierd guy, I don't know what he wants, but he is not good&quot;&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Zmień dane wroga" />
+                                        <option name="id" value="986c3e11-4120-44f1-84a5-7ffe6944acee" />
+                                        <option name="method" value="PUT" />
+                                        <option name="name" value="Modyfikuj wroga" />
+                                        <option name="sortWeight" value="7000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/enemies/update/1" />
+                                      </requestState>
+                                    </list>
+                                  </option>
+                                  <option name="sortWeight" value="1000000" />
+                                </folderState>
+                                <folderState>
+                                  <option name="id" value="89626b62-8be8-47ab-8fa6-696c19b51ad9" />
+                                  <option name="name" value="OtherInfo" />
+                                  <option name="requests">
+                                    <list>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  &quot;characterId&quot;: 1,&#10;  &quot;notes&quot;: &quot;This is a test character.&quot;,&#10;  &quot;addictions&quot;: &quot;Drugs&quot;,&#10;  &quot;reputation&quot;: &quot;Hero&quot;,&#10;  &quot;style&quot;: &quot;Stealth&quot;,&#10;  &quot;classLifePath&quot;: &quot;Worrior&quot;,&#10;  &quot;accommodation&quot;: &quot;Apartment&quot;,&#10;  &quot;rental&quot;: &quot;500&quot;,&#10;  &quot;livingStandard&quot;: &quot;High&quot;&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Tworzy info przypisane do konkretnej karty postaci" />
+                                        <option name="id" value="7156c912-c1dc-41ce-aa4d-96244489f4cd" />
+                                        <option name="method" value="POST" />
+                                        <option name="name" value="Stwórz info" />
+                                        <option name="sortWeight" value="1000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/OtherInfo/add" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Usuwa info przypisane do konkretnej karty postaci" />
+                                        <option name="id" value="2889f1c0-7992-46ae-aebb-2bf5119c4965" />
+                                        <option name="method" value="DELETE" />
+                                        <option name="name" value="Usuń info" />
+                                        <option name="sortWeight" value="2000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/OtherInfo/delete/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca każde info z każdej karty postaci" />
+                                        <option name="id" value="295b8556-564f-4020-bd14-1f4b61d0540d" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Zwróć wszystkie info" />
+                                        <option name="sortWeight" value="3000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/OtherInfo/all" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca info po unikalnym id" />
+                                        <option name="id" value="e87c6455-a946-4beb-8130-1545f9b48fae" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Zwróć info po id" />
+                                        <option name="sortWeight" value="4000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/OtherInfo/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca obiekty" />
+                                        <option name="id" value="139f0a9e-9b2f-4096-80b3-089465dab4c0" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Zwróć wszystkie info dla Admina" />
+                                        <option name="sortWeight" value="5000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/character/OtherInfo/all" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca wszystkie info z konkretnej karty postaci" />
+                                        <option name="id" value="5f6585ec-5fc6-4f6f-bb38-59734de241d4" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Zwróć info po characterId" />
+                                        <option name="sortWeight" value="6000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/OtherInfo/character/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  &quot;characterId&quot;: 1,&#10;  &quot;notes&quot;: &quot;This is a new test character.&quot;,&#10;  &quot;addictions&quot;: &quot;Drugs and Alcohol&quot;,&#10;  &quot;reputation&quot;: &quot;Drug Dealer&quot;,&#10;  &quot;style&quot;: &quot;Fast&quot;,&#10;  &quot;classLifePath&quot;: &quot;Homeless&quot;,&#10;  &quot;accommodation&quot;: &quot;Tent&quot;,&#10;  &quot;rental&quot;: &quot;600&quot;,&#10;  &quot;livingStandard&quot;: &quot;Low&quot;&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Zmień dane  w info" />
+                                        <option name="id" value="5165a1fe-56da-4a19-9215-6762d11c33c3" />
+                                        <option name="method" value="PUT" />
+                                        <option name="name" value="Modyfikuj info" />
+                                        <option name="sortWeight" value="7000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/OtherInfo/update/1" />
+                                      </requestState>
+                                    </list>
+                                  </option>
+                                  <option name="sortWeight" value="2000000" />
+                                </folderState>
+                                <folderState>
                                   <option name="id" value="709a58b8-efe6-450f-9bc4-237c1dd205da" />
                                   <option name="name" value="Classes" />
                                   <option name="requests">

--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -1598,86 +1598,217 @@
                             <option name="name" value="Compatibility" />
                             <option name="sortWeight" value="3000000" />
                           </folderState>
+                          <folderState>
+                            <option name="folders">
+                              <list>
+                                <folderState>
+                                  <option name="id" value="709a58b8-efe6-450f-9bc4-237c1dd205da" />
+                                  <option name="name" value="Classes" />
+                                  <option name="requests">
+                                    <list>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  classLevel: 1,&#10;  characterId: 1,&#10;  classId: 1&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Dodaje powiązanie klasy z daną postacią" />
+                                        <option name="id" value="4f041235-dbd7-4cd4-8c29-cab4755cdb25" />
+                                        <option name="method" value="POST" />
+                                        <option name="name" value="Dodaj klasę postaci" />
+                                        <option name="sortWeight" value="1000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/classes/create" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca wszystkie klasy wskazanej postaci po jej ID" />
+                                        <option name="id" value="fc056619-fa0c-40a2-89dc-971708765476" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobierz klasy postaci po ID postaci" />
+                                        <option name="sortWeight" value="2000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/classes/3" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca listę wszysktki powiązań postaci z klasą" />
+                                        <option name="id" value="338fb3e2-b7da-4b16-adeb-05f9c49d59d2" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobierz wszystkie klasy postaci dla Admina" />
+                                        <option name="sortWeight" value="3000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/games/cpRed/characters/classes/all" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  classLevel: 5&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Pozwala zmienić level danej clasy postaci" />
+                                        <option name="id" value="8af763e5-f529-433d-9890-703c49055f71" />
+                                        <option name="method" value="PUT" />
+                                        <option name="name" value="Modyfikuj klasę danej postaci" />
+                                        <option name="sortWeight" value="4000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/classes/update/5" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Usuwa klasę dla danej postaci" />
+                                        <option name="id" value="39fddd48-edcc-46a4-9ebc-9523cf75624c" />
+                                        <option name="method" value="DELETE" />
+                                        <option name="name" value="Usuń klasę danej postaci" />
+                                        <option name="sortWeight" value="5000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/classes/delete/6" />
+                                      </requestState>
+                                    </list>
+                                  </option>
+                                  <option name="sortWeight" value="1000000" />
+                                </folderState>
+                                <folderState>
+                                  <option name="id" value="81470128-3c31-4765-b74f-ab9d6ff1a24e" />
+                                  <option name="name" value="Stats" />
+                                  <option name="requests">
+                                    <list>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  maxStatLevel: 10,&#10;  currentStatLevel: 7,&#10;  characterId: 1,&#10;  statId: 2&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Dodaje powiązanie statystyki z postacią" />
+                                        <option name="id" value="f200ba1e-91f3-4c14-a6ef-a1c960e5a8ed" />
+                                        <option name="method" value="POST" />
+                                        <option name="name" value="Dodaj statystykę postaci" />
+                                        <option name="sortWeight" value="1000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/stats/create" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Lwarac listę statystyk postaci dla postaci o podanym ID" />
+                                        <option name="id" value="ac246ca0-a14c-4812-990e-080cc7691630" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobiera statystyki postaci po ID postaci" />
+                                        <option name="sortWeight" value="2000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/stats/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca listę wszystkich powiązań postaci z klasą" />
+                                        <option name="id" value="33fc0f01-efdd-4b43-8995-ab2ceb545105" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Pobierz wszystkie statystyki dla Admina" />
+                                        <option name="sortWeight" value="3000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/games/cpRed/characters/stats/all" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  maxStatLevel: 20,&#10;  currentStatLevel: 2&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Pozwala zmieniaćpoziom statystyk" />
+                                        <option name="id" value="35f12d6a-6a72-4aa8-99f4-a0c037f91667" />
+                                        <option name="method" value="PUT" />
+                                        <option name="name" value="Modyfikuj statystykę danej postaci" />
+                                        <option name="sortWeight" value="4000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/stats/update/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Uwuwa statystykę dla danej postaci" />
+                                        <option name="id" value="30c58374-ff13-4f74-83d1-58425b5f1859" />
+                                        <option name="method" value="DELETE" />
+                                        <option name="name" value="Usuń statystykę danej postaci" />
+                                        <option name="sortWeight" value="5000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/stats/delete/1" />
+                                      </requestState>
+                                    </list>
+                                  </option>
+                                  <option name="sortWeight" value="2000000" />
+                                </folderState>
+                              </list>
+                            </option>
+                            <option name="id" value="59cdc013-8808-4399-ab24-bcfef4ebec51" />
+                            <option name="name" value="Characters" />
+                            <option name="requests">
+                              <list>
+                                <requestState>
+                                  <option name="body">
+                                    <bodyState>
+                                      <option name="raw" value="{&#10;  &quot;game&quot;: {&#10;    &quot;id&quot;: 1&#10;  },&#10;  &quot;name&quot;: &quot;Johnny Goldboy&quot;,&#10;  &quot;nickname&quot;: &quot;Goldhand&quot;,&#10;  &quot;type&quot;: &quot;PLAYER&quot;,&#10;  &quot;expAll&quot;: 1000,&#10;  &quot;expAvailable&quot;: 500,&#10;  &quot;cash&quot;: 2000&#10;}" />
+                                      <option name="type" value="JSON" />
+                                    </bodyState>
+                                  </option>
+                                  <option name="description" value="Tworzy nową grywalną postać w systemie cyberpunka" />
+                                  <option name="id" value="6fc6c286-01db-4216-9ea8-72e07d1bb0ea" />
+                                  <option name="method" value="POST" />
+                                  <option name="name" value="Stwórz postać" />
+                                  <option name="sortWeight" value="1000000" />
+                                  <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/create" />
+                                </requestState>
+                                <requestState>
+                                  <option name="body">
+                                    <bodyState>
+                                      <option name="raw" value="{&#10;  &quot;game&quot;: {&#10;    &quot;id&quot;: 1&#10;  },&#10;  &quot;name&quot;: &quot;Adam Smasher 3&quot;,&#10;  &quot;nickname&quot;: &quot;Smasher&quot;,&#10;  &quot;type&quot;: &quot;NPC&quot;,&#10;  &quot;expAll&quot;: 5000,&#10;  &quot;expAvailable&quot;: 0,&#10;  &quot;cash&quot;: 100000&#10;}" />
+                                      <option name="type" value="JSON" />
+                                    </bodyState>
+                                  </option>
+                                  <option name="description" value="Wtorzy postać niegrywalną" />
+                                  <option name="id" value="a3844127-40cb-42cf-b4a7-15395f9e8b2f" />
+                                  <option name="method" value="POST" />
+                                  <option name="name" value="Stwórz NPC" />
+                                  <option name="sortWeight" value="2000000" />
+                                  <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/create" />
+                                </requestState>
+                                <requestState>
+                                  <option name="description" value="Zwraca wszystkie postacie" />
+                                  <option name="id" value="8ada6801-13c6-4264-9050-b2cab8fa11cb" />
+                                  <option name="method" value="GET" />
+                                  <option name="name" value="All Characters" />
+                                  <option name="sortWeight" value="3000000" />
+                                  <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/all" />
+                                </requestState>
+                                <requestState>
+                                  <option name="body">
+                                    <bodyState>
+                                      <option name="raw" value="{&#10;//  &quot;user&quot;: {&#10;//    &quot;id&quot;: 3&#10;//  },&#10;  &quot;name&quot;: &quot;Adam Smasher2&quot;,&#10;  &quot;nickname&quot;: &quot;Smasher&quot;,&#10;  &quot;expAll&quot;: 5000,&#10;  &quot;expAvailable&quot;: 0,&#10;  &quot;cash&quot;: 100000&#10;}" />
+                                      <option name="type" value="JSON" />
+                                    </bodyState>
+                                  </option>
+                                  <option name="description" value="Pozwala na modyfikacje danych postaci" />
+                                  <option name="id" value="0a04e0cf-9e18-497f-afa3-8d830117dc72" />
+                                  <option name="method" value="PUT" />
+                                  <option name="name" value="Modyfikuj postać" />
+                                  <option name="sortWeight" value="4000000" />
+                                  <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/update/3" />
+                                </requestState>
+                                <requestState>
+                                  <option name="body">
+                                    <bodyState>
+                                      <option name="raw" value="{&#10;  &quot;user&quot;: null,&#10;  &quot;type&quot;: &quot;NPC&quot;,&#10;} " />
+                                      <option name="type" value="JSON" />
+                                    </bodyState>
+                                  </option>
+                                  <option name="description" value="Usuwa usera z postaci" />
+                                  <option name="id" value="8595f81c-9831-4056-b5a8-09c8b3b50d5b" />
+                                  <option name="method" value="PUT" />
+                                  <option name="name" value="Zrób z postaci NPC" />
+                                  <option name="sortWeight" value="5000000" />
+                                  <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/playerToNpc/3" />
+                                </requestState>
+                                <requestState>
+                                  <option name="description" value="Zmienia parametr alive " />
+                                  <option name="id" value="1287af64-6ca1-4311-b691-ef8e41f5198a" />
+                                  <option name="method" value="PUT" />
+                                  <option name="name" value="Zmień czy postać żyje" />
+                                  <option name="sortWeight" value="6000000" />
+                                  <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/changeAlive/3" />
+                                </requestState>
+                              </list>
+                            </option>
+                            <option name="sortWeight" value="4000000" />
+                          </folderState>
                         </list>
                       </option>
                       <option name="id" value="be9e305b-7eae-442e-9183-34c14c9991a5" />
                       <option name="name" value="CpRed" />
-                      <option name="requests">
-                        <list>
-                          <requestState>
-                            <option name="body">
-                              <bodyState>
-                                <option name="raw" value="{&#10;  &quot;game&quot;: {&#10;    &quot;id&quot;: 1&#10;  },&#10;  &quot;name&quot;: &quot;Johnny Goldboy&quot;,&#10;  &quot;nickname&quot;: &quot;Goldhand&quot;,&#10;  &quot;type&quot;: &quot;PLAYER&quot;,&#10;  &quot;expAll&quot;: 1000,&#10;  &quot;expAvailable&quot;: 500,&#10;  &quot;cash&quot;: 2000&#10;}" />
-                                <option name="type" value="JSON" />
-                              </bodyState>
-                            </option>
-                            <option name="description" value="Tworzy nową grywalną postać w systemie cyberpunka" />
-                            <option name="id" value="6fc6c286-01db-4216-9ea8-72e07d1bb0ea" />
-                            <option name="method" value="POST" />
-                            <option name="name" value="Stwórz postać" />
-                            <option name="sortWeight" value="1000000" />
-                            <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/create" />
-                          </requestState>
-                          <requestState>
-                            <option name="body">
-                              <bodyState>
-                                <option name="raw" value="{&#10;  &quot;game&quot;: {&#10;    &quot;id&quot;: 1&#10;  },&#10;  &quot;name&quot;: &quot;Adam Smasher 3&quot;,&#10;  &quot;nickname&quot;: &quot;Smasher&quot;,&#10;  &quot;type&quot;: &quot;NPC&quot;,&#10;  &quot;expAll&quot;: 5000,&#10;  &quot;expAvailable&quot;: 0,&#10;  &quot;cash&quot;: 100000&#10;}" />
-                                <option name="type" value="JSON" />
-                              </bodyState>
-                            </option>
-                            <option name="description" value="Wtorzy postać niegrywalną" />
-                            <option name="id" value="a3844127-40cb-42cf-b4a7-15395f9e8b2f" />
-                            <option name="method" value="POST" />
-                            <option name="name" value="Stwórz NPC" />
-                            <option name="sortWeight" value="2000000" />
-                            <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/create" />
-                          </requestState>
-                          <requestState>
-                            <option name="description" value="Zwraca wszystkie postacie" />
-                            <option name="id" value="8ada6801-13c6-4264-9050-b2cab8fa11cb" />
-                            <option name="method" value="GET" />
-                            <option name="name" value="All Characters" />
-                            <option name="sortWeight" value="3000000" />
-                            <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/all" />
-                          </requestState>
-                          <requestState>
-                            <option name="body">
-                              <bodyState>
-                                <option name="raw" value="{&#10;//  &quot;user&quot;: {&#10;//    &quot;id&quot;: 3&#10;//  },&#10;  &quot;name&quot;: &quot;Adam Smasher2&quot;,&#10;  &quot;nickname&quot;: &quot;Smasher&quot;,&#10;  &quot;expAll&quot;: 5000,&#10;  &quot;expAvailable&quot;: 0,&#10;  &quot;cash&quot;: 100000&#10;}" />
-                                <option name="type" value="JSON" />
-                              </bodyState>
-                            </option>
-                            <option name="description" value="Pozwala na modyfikacje danych postaci" />
-                            <option name="id" value="0a04e0cf-9e18-497f-afa3-8d830117dc72" />
-                            <option name="method" value="PUT" />
-                            <option name="name" value="Modyfikuj postać" />
-                            <option name="sortWeight" value="4000000" />
-                            <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/update/3" />
-                          </requestState>
-                          <requestState>
-                            <option name="body">
-                              <bodyState>
-                                <option name="raw" value="{&#10;  &quot;user&quot;: null,&#10;  &quot;type&quot;: &quot;NPC&quot;,&#10;} " />
-                                <option name="type" value="JSON" />
-                              </bodyState>
-                            </option>
-                            <option name="description" value="Usuwa usera z postaci" />
-                            <option name="id" value="8595f81c-9831-4056-b5a8-09c8b3b50d5b" />
-                            <option name="method" value="PUT" />
-                            <option name="name" value="Zrób z postaci NPC" />
-                            <option name="sortWeight" value="5000000" />
-                            <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/playerToNpc/3" />
-                          </requestState>
-                          <requestState>
-                            <option name="description" value="Zmienia parametr alive " />
-                            <option name="id" value="1287af64-6ca1-4311-b691-ef8e41f5198a" />
-                            <option name="method" value="PUT" />
-                            <option name="name" value="Zmień czy postać żyje" />
-                            <option name="sortWeight" value="6000000" />
-                            <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/changeAlive/3" />
-                          </requestState>
-                        </list>
-                      </option>
                       <option name="sortWeight" value="1000000" />
                     </folderState>
                   </list>

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterStats/AddCharacterStatsRequest.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterStats/AddCharacterStatsRequest.java
@@ -2,12 +2,14 @@ package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterStats;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @AllArgsConstructor
-@ToString
-public class CpRedCharacterStatsDTO {
+@NoArgsConstructor
+public class AddCharacterStatsRequest {
     private Integer maxStatLevel;
     private Integer currentStatLevel;
     private Long characterId;

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterStats/CpRedCharacterStats.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterStats/CpRedCharacterStats.java
@@ -25,8 +25,8 @@ public class CpRedCharacterStats {
     )
     private Long id;
 
-    private int maxStatLevel;
-    private int currentStatLevel;
+    private Integer maxStatLevel;
+    private Integer currentStatLevel;
 
     @ManyToOne
     @JoinColumn(

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterStats/CpRedCharacterStatsController.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterStats/CpRedCharacterStatsController.java
@@ -1,0 +1,41 @@
+package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterStats;
+
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping(path = "api/v1/authorized")
+@AllArgsConstructor
+public class CpRedCharacterStatsController {
+    private final CpRedCharacterStatsService cpRedCharacterStatsService;
+
+    // ============ User methods ============
+    @GetMapping(path ="/games/cpRed/characters/stats/{characterId}")
+    public Map<String, Object> getCharacterStats(@PathVariable("characterId")Long characterId) {
+        return cpRedCharacterStatsService.getCharacterStats(characterId);
+    }
+
+    @PostMapping(path = "/games/cpRed/characters/stats/create")
+    public Map<String, Object> createCharacterStats(@RequestBody AddCharacterStatsRequest addCharacterStatsRequest) {
+        return cpRedCharacterStatsService.createCharacterStats(addCharacterStatsRequest);
+    }
+
+    @PutMapping(path = "/games/cpRed/characters/stats/update/{characterStatsId}")
+    public Map<String, Object> updateCharacterStats(@PathVariable("characterStatsId") Long characterStatsId,
+                                                    @RequestBody UpdateCharacterStatsRequest updateCharacterStatsRequest) {
+        return cpRedCharacterStatsService.updateCharacterStats(characterStatsId, updateCharacterStatsRequest);
+    }
+
+    @DeleteMapping(path = "/games/cpRed/characters/stats/delete/{characterStatsId}")
+    public Map<String, Object> deleteCharacterStats(@PathVariable("characterStatsId") Long characterStatsId) {
+        return cpRedCharacterStatsService.deleteCharacterStats(characterStatsId);
+    }
+
+    // ============ Admin methods ============
+    @GetMapping(path = "/admin/games/cpRed/characters/stats/all")
+    public Map<String, Object> getAllCharacterStats() {
+        return cpRedCharacterStatsService.getAllCharacterStats();
+    }
+}

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterStats/CpRedCharacterStatsDTO.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterStats/CpRedCharacterStatsDTO.java
@@ -8,6 +8,7 @@ import lombok.ToString;
 @AllArgsConstructor
 @ToString
 public class CpRedCharacterStatsDTO {
+    private Long id;
     private Integer maxStatLevel;
     private Integer currentStatLevel;
     private Long characterId;

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterStats/CpRedCharacterStatsRepository.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterStats/CpRedCharacterStatsRepository.java
@@ -1,8 +1,16 @@
 package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterStats;
 
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharacters;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.manual.stats.CpRedStats;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Arrays;
+import java.util.List;
+
 @Repository
 public interface CpRedCharacterStatsRepository extends JpaRepository<CpRedCharacterStats, Long> {
+    List<CpRedCharacterStats> getCharacterStatsByCharacterId(CpRedCharacters character);
+
+    boolean existsByCharacterIdAndStatId(CpRedCharacters character, CpRedStats stat);
 }

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterStats/CpRedCharacterStatsService.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterStats/CpRedCharacterStatsService.java
@@ -1,0 +1,241 @@
+package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterStats;
+
+import dev.goral.rpghandyhelper.game.Game;
+import dev.goral.rpghandyhelper.game.GameRepository;
+import dev.goral.rpghandyhelper.game.gameUsers.GameUsers;
+import dev.goral.rpghandyhelper.game.gameUsers.GameUsersRepository;
+import dev.goral.rpghandyhelper.game.gameUsers.GameUsersRole;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharacters;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharactersRepository;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharactersType;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.manual.stats.CpRedStats;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.manual.stats.CpRedStatsRepository;
+import dev.goral.rpghandyhelper.security.CustomReturnables;
+import dev.goral.rpghandyhelper.security.exceptions.ResourceNotFoundException;
+import dev.goral.rpghandyhelper.user.User;
+import dev.goral.rpghandyhelper.user.UserRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@Service
+@AllArgsConstructor
+public class CpRedCharacterStatsService {
+    private final CpRedCharacterStatsRepository cpRedCharacterStatsRepository;
+    private final UserRepository userRepository;
+    private final CpRedCharactersRepository cpRedCharactersRepository;
+    private final CpRedStatsRepository cpRedStatsRepository;
+    private final GameRepository gameRepository;
+    private final GameUsersRepository gameUsersRepository;
+
+    public Map<String, Object> getCharacterStats(Long characterId){
+        CpRedCharacters character = cpRedCharactersRepository.findById(characterId)
+                .orElseThrow(() -> new ResourceNotFoundException("Postać o podanym ID nie została znaleziona."));
+        List<CpRedCharacterStatsDTO> characterStats = cpRedCharacterStatsRepository.getCharacterStatsByCharacterId(character).stream()
+                .map(stats -> new CpRedCharacterStatsDTO(
+                        stats.getMaxStatLevel(),
+                        stats.getCurrentStatLevel(),
+                        stats.getCharacterId().getId(),
+                        stats.getStatId().getId()))
+                .toList();
+
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Statystyki postaci pobrane pomyślnie");
+        response.put("characterStats", characterStats);
+        return response;
+    }
+
+    public Map<String, Object> createCharacterStats(AddCharacterStatsRequest addCharacterStatsRequest){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
+
+        // Czy podano wszystkie wymagane pola w request
+        if (addCharacterStatsRequest.getMaxStatLevel() == null || addCharacterStatsRequest.getCurrentStatLevel() == null ||
+                addCharacterStatsRequest.getCharacterId() == null || addCharacterStatsRequest.getStatId() == null) {
+            throw new IllegalArgumentException("Wszystkie pola muszą być wypełnione.");
+        }
+
+        // Czy istnieje character o podanym ID
+        CpRedCharacters character = cpRedCharactersRepository.findById(addCharacterStatsRequest.getCharacterId())
+                .orElseThrow(() -> new ResourceNotFoundException("Postać o podanym ID nie została znaleziona."));
+
+        // Czy istnieje statystyka o podanym ID
+        CpRedStats stat = cpRedStatsRepository.findById(addCharacterStatsRequest.getStatId())
+                .orElseThrow(() -> new ResourceNotFoundException("Statystyka o podanym ID nie została znaleziona."));
+
+        // Sprawdzenie, czy statystyka już istnieje dla tej postaci
+        if (cpRedCharacterStatsRepository.existsByCharacterIdAndStatId(character, stat)) {
+            throw new IllegalArgumentException("Statystyka o podanym ID już istnieje dla tej postaci.");
+        }
+
+        Game game = gameRepository.findById(character.getGame().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Gra powiązana z postacią nie została znaleziona."));
+
+        // Czy użytkownik należy do gry, do której należy postać
+        GameUsers gameUsers = gameUsersRepository.findGameUsersByUserIdAndGameId(currentUser.getId(), game.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Nie należysz do gry powiązanej z podaną postacią."));
+
+        // Czy ktoś chce zmieniać swoją postać lub jest GM-em w tej grze
+        if (gameUsers.getRole() != GameUsersRole.GAMEMASTER){
+            if (character.getType() != CpRedCharactersType.NPC) {
+                if (!Objects.equals(currentUser.getId(), character.getUser().getId())) {
+                    throw new ResourceNotFoundException("Zalogowany użytkownik nie jest GM-em w tej grze ani nie jest właścicielem postaci.");
+                }
+            } else {
+                throw new ResourceNotFoundException("Tylko GM może zmieniać statystyki postaci NPC.");
+            }
+        }
+
+        // Czy maksymalna statystyka jest potrzebna
+        if (stat.isChangeable()){
+            // Czy maksymalny poziom statystyki jet większy od -1 i mniejsza od 21
+            if (addCharacterStatsRequest.getMaxStatLevel() < 0 || addCharacterStatsRequest.getMaxStatLevel() > 20) {
+                throw new IllegalArgumentException("Maksymalny poziom statystyki musi być z zakresu od 0 do 20.");
+            }
+            // Czy aktualny poziom statystyki jet większy od -1 i mniejsza od 21
+            if (addCharacterStatsRequest.getCurrentStatLevel() < 0 || addCharacterStatsRequest.getCurrentStatLevel() > 20) {
+                throw new IllegalArgumentException("Aktualny poziom statystyki musi być z zakresu od 0 do 20");
+            }
+            // Czy aktualny poziom statystyki jest nie większy od maksymalnego poziomu statystyki
+            if (addCharacterStatsRequest.getCurrentStatLevel() > addCharacterStatsRequest.getMaxStatLevel()) {
+                throw new IllegalArgumentException("Aktualny poziom statystyki nie może być większy niż maksymalny poziom statystyki.");
+            }
+        } else {
+            // Czy aktualny poziom statystyki jet większy od -1 i mniejsza od 21
+            if (addCharacterStatsRequest.getCurrentStatLevel() < 0 || addCharacterStatsRequest.getCurrentStatLevel() > 20) {
+                throw new IllegalArgumentException("Aktualny poziom statystyki musi być z zakresu od 0 do 20");
+            }
+        }
+
+        // Tworzenie nowej klasy postaci
+        CpRedCharacterStats newCharacterStats = new CpRedCharacterStats(
+                null,
+                addCharacterStatsRequest.getMaxStatLevel(),
+                addCharacterStatsRequest.getCurrentStatLevel(),
+                character,
+                stat
+        );
+        cpRedCharacterStatsRepository.save(newCharacterStats);
+
+        return CustomReturnables.getOkResponseMap("Statystyka postaci została pomyślnie utworzona");
+    }
+
+    public Map<String, Object> updateCharacterStats(Long characterStatsId, UpdateCharacterStatsRequest updateCharacterStatsRequest){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
+
+        // Czy istnieje statystyka o podanym ID
+        CpRedCharacterStats characterStatsToUpdate = cpRedCharacterStatsRepository.findById(characterStatsId)
+                .orElseThrow(() -> new ResourceNotFoundException("Statystyka postaci o podanym ID nie została znaleziona."));
+
+        // Czy istnieje character o podanym ID
+        CpRedCharacters character = cpRedCharactersRepository.findById(characterStatsToUpdate.getCharacterId().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Postać o podanym ID nie została znaleziona."));
+
+        Game game = gameRepository.findById(character.getGame().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Gra powiązana z postacią nie została znaleziona."));
+
+        // Czy użytkownik należy do gry, do której należy postać
+        GameUsers gameUsers = gameUsersRepository.findGameUsersByUserIdAndGameId(currentUser.getId(), game.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Nie należysz do gry powiązanej z podaną postacią."));
+
+        CpRedStats stat = cpRedStatsRepository.findById(characterStatsToUpdate.getStatId().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Powiązana statystyka nie została znaleziona."));
+
+        // Czy ktoś chce zmieniać swoją postać lub jest GM-em w tej grze
+        if (gameUsers.getRole() != GameUsersRole.GAMEMASTER){
+            if (character.getType() != CpRedCharactersType.NPC) {
+                if (!Objects.equals(currentUser.getId(), character.getUser().getId())) {
+                    throw new ResourceNotFoundException("Zalogowany użytkownik nie jest GM-em w tej grze ani nie jest właścicielem postaci.");
+                }
+            } else {
+                throw new ResourceNotFoundException("Tylko GM może zmieniać statystyki postaci NPC.");
+            }
+        }
+
+        // Czy statystyka jest zmienna
+        if (!stat.isChangeable() && updateCharacterStatsRequest.getMaxStatLevel() != null){
+            throw new IllegalArgumentException("Ta statystyka nie jest zmienna, więc nie możesz ustawić maksymalnego poziomu statystyki");
+        }
+
+        // Sprawdzenie maksymalnego poziomu statystyki
+        if (updateCharacterStatsRequest.getMaxStatLevel() != null) {
+            if (updateCharacterStatsRequest.getMaxStatLevel() < 0 || updateCharacterStatsRequest.getMaxStatLevel() > 20) {
+                throw new IllegalArgumentException("Maksymalny poziom statystyki musi być z zakresu od 0 do 20.");
+            }
+            if (updateCharacterStatsRequest.getMaxStatLevel() < characterStatsToUpdate.getCurrentStatLevel()) {
+                throw new IllegalArgumentException("Maksymalny poziom statystyki nie może być mniejszy niż aktualny poziom statystyki.");
+            }
+            characterStatsToUpdate.setMaxStatLevel(updateCharacterStatsRequest.getMaxStatLevel());
+        }
+
+        // Sprawdzenie aktualnego poziomu statystyki
+        if (updateCharacterStatsRequest.getCurrentStatLevel() != null) {
+            if (updateCharacterStatsRequest.getCurrentStatLevel() < 0 || updateCharacterStatsRequest.getCurrentStatLevel() > 20) {
+                throw new IllegalArgumentException("Aktualny poziom statystyki musi być z zakresu od 0 do 20");
+            }
+            // Czy aktualny poziom statystyki jest nie większy od maksymalnego poziomu statystyki
+            if (updateCharacterStatsRequest.getCurrentStatLevel() > characterStatsToUpdate.getMaxStatLevel()) {
+                throw new IllegalArgumentException("Aktualny poziom statystyki nie może być większy niż maksymalny poziom statystyki.");
+            }
+            characterStatsToUpdate.setCurrentStatLevel(updateCharacterStatsRequest.getCurrentStatLevel());
+        }
+
+        cpRedCharacterStatsRepository.save(characterStatsToUpdate);
+        return CustomReturnables.getOkResponseMap("Statystyka postaci została pomyślnie zaktualizowana");
+    }
+
+    public Map<String, Object> deleteCharacterStats(Long characterStatsId){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
+
+        // Czy istnieje statystyka o podanym ID
+        CpRedCharacterStats characterStatsToUpdate = cpRedCharacterStatsRepository.findById(characterStatsId)
+                .orElseThrow(() -> new ResourceNotFoundException("Statystyka postaci o podanym ID nie została znaleziona."));
+
+        // Czy istnieje character o podanym ID
+        CpRedCharacters character = cpRedCharactersRepository.findById(characterStatsToUpdate.getCharacterId().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Postać o podanym ID nie została znaleziona."));
+
+        Game game = gameRepository.findById(character.getGame().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Gra powiązana z postacią nie została znaleziona."));
+
+        // Czy użytkownik należy do gry, do której należy postać
+        GameUsers gameUsers = gameUsersRepository.findGameUsersByUserIdAndGameId(currentUser.getId(), game.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Nie należysz do gry powiązanej z podaną postacią."));
+
+        // Czy ktoś chce zmieniać swoją postać lub jest GM-em w tej grze
+        if (gameUsers.getRole() != GameUsersRole.GAMEMASTER){
+            if (character.getType() != CpRedCharactersType.NPC) {
+                if (!Objects.equals(currentUser.getId(), character.getUser().getId())) {
+                    throw new ResourceNotFoundException("Zalogowany użytkownik nie jest GM-em w tej grze ani nie jest właścicielem postaci.");
+                }
+            } else {
+                throw new ResourceNotFoundException("Tylko GM może zmieniać statystyki postaci NPC.");
+            }
+        }
+
+        // Usuwanie statystyki postaci
+        cpRedCharacterStatsRepository.deleteById(characterStatsId);
+
+        return CustomReturnables.getOkResponseMap("Statystyka postaci została pomyślnie usunięta");
+    }
+
+    public Map<String, Object> getAllCharacterStats() {
+        List<CpRedCharacterStats> allCharacterStats = cpRedCharacterStatsRepository.findAll();
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Wszystkie statystyki każdej postaci pobrane pomyślnie");
+        response.put("characterStats", allCharacterStats);
+        return response;
+    }
+
+}

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterStats/CpRedCharacterStatsService.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterStats/CpRedCharacterStatsService.java
@@ -2,6 +2,7 @@ package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterStats;
 
 import dev.goral.rpghandyhelper.game.Game;
 import dev.goral.rpghandyhelper.game.GameRepository;
+import dev.goral.rpghandyhelper.game.GameStatus;
 import dev.goral.rpghandyhelper.game.gameUsers.GameUsers;
 import dev.goral.rpghandyhelper.game.gameUsers.GameUsersRepository;
 import dev.goral.rpghandyhelper.game.gameUsers.GameUsersRole;
@@ -70,11 +71,6 @@ public class CpRedCharacterStatsService {
         CpRedStats stat = cpRedStatsRepository.findById(addCharacterStatsRequest.getStatId())
                 .orElseThrow(() -> new ResourceNotFoundException("Statystyka o podanym ID nie została znaleziona."));
 
-        // Sprawdzenie, czy statystyka już istnieje dla tej postaci
-        if (cpRedCharacterStatsRepository.existsByCharacterIdAndStatId(character, stat)) {
-            throw new IllegalArgumentException("Statystyka o podanym ID już istnieje dla tej postaci.");
-        }
-
         Game game = gameRepository.findById(character.getGame().getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Gra powiązana z postacią nie została znaleziona."));
 
@@ -91,6 +87,16 @@ public class CpRedCharacterStatsService {
             } else {
                 throw new ResourceNotFoundException("Tylko GM może zmieniać statystyki postaci NPC.");
             }
+        }
+
+        // Czy gra jest aktywna
+        if (game.getStatus() != GameStatus.ACTIVE) {
+            throw new IllegalStateException("Gra do której należy postać nie jest aktywna.");
+        }
+
+        // Sprawdzenie, czy statystyka już istnieje dla tej postaci
+        if (cpRedCharacterStatsRepository.existsByCharacterIdAndStatId(character, stat)) {
+            throw new IllegalArgumentException("Statystyka o podanym ID już istnieje dla tej postaci.");
         }
 
         // Czy maksymalna statystyka jest potrzebna
@@ -169,6 +175,11 @@ public class CpRedCharacterStatsService {
             }
         }
 
+        // Czy gra jest aktywna
+        if (game.getStatus() != GameStatus.ACTIVE) {
+            throw new IllegalStateException("Gra do której należy postać nie jest aktywna.");
+        }
+
         // Czy statystyka jest zmienna
         if (!stat.isChangeable() && updateCharacterStatsRequest.getMaxStatLevel() != null){
             throw new IllegalArgumentException("Ta statystyka nie jest zmienna, więc nie możesz ustawić maksymalnego poziomu statystyki");
@@ -233,6 +244,11 @@ public class CpRedCharacterStatsService {
             } else {
                 throw new ResourceNotFoundException("Tylko GM może zmieniać statystyki postaci NPC.");
             }
+        }
+
+        // Czy gra jest aktywna
+        if (game.getStatus() != GameStatus.ACTIVE) {
+            throw new IllegalStateException("Gra do której należy postać nie jest aktywna.");
         }
 
         // Usuwanie statystyki postaci

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterStats/UpdateCharacterStatsRequest.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterStats/UpdateCharacterStatsRequest.java
@@ -2,14 +2,14 @@ package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterStats;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @AllArgsConstructor
-@ToString
-public class CpRedCharacterStatsDTO {
+@NoArgsConstructor
+public class UpdateCharacterStatsRequest {
     private Integer maxStatLevel;
     private Integer currentStatLevel;
-    private Long characterId;
-    private Long statId;
 }


### PR DESCRIPTION
# Info dla testerów
## Kontekst
Encja łącząca `character` ze `stats`. Każdy obiekt zawiera 5 pola:

- `id` - wiadomo, jest to indeks połączenia
- `maxStatLevel` - maksymalny poziom danej statystyki, uwaga to pole może mieć wartość `null` w sytuacji kiedy przypisana statystyka jest nie zmienialna ( czyli w statystyce pole `isChengale` = `false`)
- `currentStatLevel` - obecny poziom danej statystyki
- `characterId` - połączona postać
- `statId` - połączona statystyka

Maksymalna wartość statystyk to 20 ale jeżeli statystyka jest zmienialna to logicznie `currentStatLevel` nie może być większe niż `maxStatLevel`.

Uprawnieniowo tak samo jak w poprzedniej PRce: Dodać/ modyfikować/usunąć klasę do danej postaci może tylko GM gry do której przypisana jest postać lub właściciel postaci.

## Endpointy
Do przetestowania 5 endpointów:

- `http://localhost:8888/api/v1/authorized/games/cpRed/characters/stats/create` - dodaje nową statystykę dla danej postaci, w momencie kiedy podawana statystyka jest niezmienna to pole `maxStatLevel` może zostać nie podane lub ustawione na `null`.
- `http://localhost:8888/api/v1/authorized/games/cpRed/characters/stats/*` - zwraca listę statystyk dla podanej po id postaci
- `http://localhost:8888/api/v1/authorized/admin/games/cpRed/characters/stats/all` - zwraca listę wszystkich powiązań między statystyką i postacią.
- `http://localhost:8888/api/v1/authorized/games/cpRed/characters/stats/update/*` - modyfikuje statystykę o podanym id, w momencie kiedy statystyka jest niezmienna to pole `maxStatLevel` może zostać nie podane lub ustawione na `null`. Można modyfikować tylko `maxStatLevel` i `currentStatLevel`. Jeśli chcemy zmienić tylko jedno to podajemy to co chcemy zmienić.
- `http://localhost:8888/api/v1/authorized/games/cpRed/characters/stats/delete/*` - usuwa połączenie o podanym `id`

## Na koniec
Standardowo na branchu są zapytania w `Jetclienice` zrobione, a na discordzie macie zmodyfikowany `Config` dla tej PRki.
Miłego testowania ;)