### PR TITLE
pierwsza działająca wersja

### DIFF
--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -88,7 +88,7 @@
                       <option name="method" value="POST" />
                       <option name="name" value="Login Admin" />
                       <option name="sortWeight" value="3000000" />
-                      <option name="url" value="+http://localhost:8888/login" />
+                      <option name="url" value="http://localhost:8888/login" />
                     </requestState>
                     <requestState>
                       <option name="body">
@@ -1883,11 +1883,123 @@
                                       <folderState>
                                         <option name="id" value="bac4ab85-d8d7-4065-8749-e76bd971d97c" />
                                         <option name="name" value="Manual" />
+                                        <option name="requests">
+                                          <list>
+                                            <requestState>
+                                              <option name="body">
+                                                <bodyState>
+                                                  <option name="raw" value="{&#10;  baseWeaponId: 2,&#10;  characterId: 1,&#10;  status: &quot;EQUIPPED&quot; // &quot;STORED&quot;, &quot;EQUIPPED&quot;&#10;}" />
+                                                  <option name="type" value="JSON" />
+                                                </bodyState>
+                                              </option>
+                                              <option name="description" value="Dodaje wskazaną broń do postaci" />
+                                              <option name="id" value="26cd49e1-913a-4f72-9803-09cb38e0254d" />
+                                              <option name="method" value="POST" />
+                                              <option name="name" value="Dodaj broń do postaci" />
+                                              <option name="sortWeight" value="1000000" />
+                                              <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/weapons/create" />
+                                            </requestState>
+                                            <requestState>
+                                              <option name="description" value="Zwraca listę z wszystkimi broniami postaci o podanym id" />
+                                              <option name="id" value="c0e68eec-d051-4718-8a3d-fe6dbcc07799" />
+                                              <option name="method" value="GET" />
+                                              <option name="name" value="Pobierz wszystkie bronie postaci" />
+                                              <option name="sortWeight" value="2000000" />
+                                              <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/weapons/1" />
+                                            </requestState>
+                                            <requestState>
+                                              <option name="description" value="Zwraca listę wszystkich powiązń postaci z bronią" />
+                                              <option name="id" value="3424231a-6f39-4c25-9e61-dc035316b04f" />
+                                              <option name="method" value="GET" />
+                                              <option name="name" value="Pobierz wszysktie bronie postaci dla Admina" />
+                                              <option name="sortWeight" value="3000000" />
+                                              <option name="url" value="http://localhost:8888/api/v1/authorized/admin/games/cpRed/characters/weapons/all" />
+                                            </requestState>
+                                            <requestState>
+                                              <option name="body">
+                                                <bodyState>
+                                                  <option name="raw" value="{&#10;  dmg: 10,&#10;  magazineCapacity: 100,&#10;  numberOfAttacks: 4,&#10;  handType: 3,&#10;  isHidden: true,&#10;  quality: &quot;STANDARD&quot;, // &quot;POOR&quot;, &quot;STANDARD&quot;, &quot;EXCELLENT&quot;&#10;  status: &quot;EQUIPPED&quot;, // &quot;STORED&quot;, &quot;EQUIPPED&quot;&#10;  description: &quot;Taka giwera że ja pie....&quot;,&#10;}" />
+                                                  <option name="type" value="JSON" />
+                                                </bodyState>
+                                              </option>
+                                              <option name="description" value="Pozwala modyfikować parametry broni przypisanej do użytkownika" />
+                                              <option name="id" value="9723acd5-d018-4a88-ad4e-4c453e9d74fc" />
+                                              <option name="method" value="PUT" />
+                                              <option name="name" value="Modyfikuj broń postaci" />
+                                              <option name="sortWeight" value="4000000" />
+                                              <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/weapons/update/1" />
+                                            </requestState>
+                                            <requestState>
+                                              <option name="description" value="Usuwa powiązanie wybranej po ID broni z userem" />
+                                              <option name="id" value="4f6eced3-ed9a-4f81-9a9b-b9067464798b" />
+                                              <option name="method" value="DELETE" />
+                                              <option name="name" value="Usuń powiązanie broni z postacią" />
+                                              <option name="sortWeight" value="5000000" />
+                                              <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/weapons/delete/1" />
+                                            </requestState>
+                                          </list>
+                                        </option>
                                         <option name="sortWeight" value="1000000" />
                                       </folderState>
                                       <folderState>
                                         <option name="id" value="582bcc4d-1b80-4e9c-ba0b-bae39cc50708" />
                                         <option name="name" value="Custom" />
+                                        <option name="requests">
+                                          <list>
+                                            <requestState>
+                                              <option name="body">
+                                                <bodyState>
+                                                  <option name="raw" value="{&#10;  baseWeaponId: 2,&#10;  characterId: 1,&#10;  status: &quot;EQUIPPED&quot; // &quot;STORED&quot;, &quot;EQUIPPED&quot;&#10;}" />
+                                                  <option name="type" value="JSON" />
+                                                </bodyState>
+                                              </option>
+                                              <option name="description" value="Dodaje wskazaną customową broń do postaci" />
+                                              <option name="id" value="c30fb7e9-a0e3-4540-bdf8-de9d228ca320" />
+                                              <option name="method" value="POST" />
+                                              <option name="name" value="Dodaj customową broń do postaci" />
+                                              <option name="sortWeight" value="1000000" />
+                                              <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/customWeapons/create" />
+                                            </requestState>
+                                            <requestState>
+                                              <option name="description" value="Zwraca listę z wszystkimi customowymi broniami postaci o podanym id" />
+                                              <option name="id" value="450db32b-77b1-45de-b06c-bf82a244504a" />
+                                              <option name="method" value="GET" />
+                                              <option name="name" value="Pobierz wszystkie customowe bronie postaci" />
+                                              <option name="sortWeight" value="2000000" />
+                                              <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/customWeapons/1" />
+                                            </requestState>
+                                            <requestState>
+                                              <option name="description" value="Zwraca listę wszystkich powiązń customowych postaci z bronią" />
+                                              <option name="id" value="0fbb5c54-f7e9-43c7-8349-e8b1fa5f24b9" />
+                                              <option name="method" value="GET" />
+                                              <option name="name" value="Pobierz wszysktie customowe bronie postaci dla Admina" />
+                                              <option name="sortWeight" value="3000000" />
+                                              <option name="url" value="http://localhost:8888/api/v1/authorized/admin/games/cpRed/characters/customWeapons/all" />
+                                            </requestState>
+                                            <requestState>
+                                              <option name="body">
+                                                <bodyState>
+                                                  <option name="raw" value="{&#10;  dmg: 10,&#10;  magazineCapacity: 100,&#10;  numberOfAttacks: 4,&#10;  handType: 3,&#10;  isHidden: true,&#10;  quality: &quot;STANDARD&quot;, // &quot;POOR&quot;, &quot;STANDARD&quot;, &quot;EXCELLENT&quot;&#10;  status: &quot;EQUIPPED&quot;, // &quot;STORED&quot;, &quot;EQUIPPED&quot;&#10;  description: &quot;Taka giwera że ja pie....&quot;,&#10;}" />
+                                                  <option name="type" value="JSON" />
+                                                </bodyState>
+                                              </option>
+                                              <option name="description" value="Pozwala modyfikować parametry customowej broni przypisanej do użytkownika" />
+                                              <option name="id" value="8b8fc000-241c-4da2-b6f3-73051e4438b8" />
+                                              <option name="method" value="PUT" />
+                                              <option name="name" value="Modyfikuj customową broń postaci" />
+                                              <option name="sortWeight" value="4000000" />
+                                              <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/customWeapons/update/1" />
+                                            </requestState>
+                                            <requestState>
+                                              <option name="description" value="Usuwa powiązanie wybranej po ID customowej broni z userem" />
+                                              <option name="id" value="e5e1c14c-a45b-4686-9f36-f81331b4909c" />
+                                              <option name="method" value="DELETE" />
+                                              <option name="name" value="Usuń powiązanie customowej broni z postacią" />
+                                              <option name="sortWeight" value="5000000" />
+                                              <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/customWeapons/delete/1" />
+                                            </requestState>
+                                          </list>
+                                        </option>
                                         <option name="sortWeight" value="2000000" />
                                       </folderState>
                                       <folderState>
@@ -1904,62 +2016,6 @@
                                   </option>
                                   <option name="id" value="d8054db5-812a-4463-a768-f882329afd47" />
                                   <option name="name" value="Weapon" />
-                                  <option name="requests">
-                                    <list>
-                                      <requestState>
-                                        <option name="body">
-                                          <bodyState>
-                                            <option name="raw" value="{&#10;  baseWeaponId: 2,&#10;  characterId: 1,&#10;  status: &quot;EQUIPPED&quot; // &quot;STORED&quot;, &quot;EQUIPPED&quot;&#10;}" />
-                                            <option name="type" value="JSON" />
-                                          </bodyState>
-                                        </option>
-                                        <option name="description" value="Dodaje wskazanąbroń do postaci" />
-                                        <option name="id" value="e614429c-a16f-48fd-b8c7-b5f4655582bc" />
-                                        <option name="method" value="POST" />
-                                        <option name="name" value="Dodaj broń do postaci" />
-                                        <option name="sortWeight" value="1000000" />
-                                        <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/weapons/create" />
-                                      </requestState>
-                                      <requestState>
-                                        <option name="description" value="Zwraca listę z wszystkimi broniami postaci o podanym id" />
-                                        <option name="id" value="d9fb92a4-5c2f-4919-a66e-63071a3766af" />
-                                        <option name="method" value="GET" />
-                                        <option name="name" value="Pobierz wszystkie bronie postaci" />
-                                        <option name="sortWeight" value="2000000" />
-                                        <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/weapons/1" />
-                                      </requestState>
-                                      <requestState>
-                                        <option name="description" value="Zwraca listę wszystkich powiązń postaci z bronią" />
-                                        <option name="id" value="8bb69a6e-d3a9-44ec-b174-353368430ce4" />
-                                        <option name="method" value="GET" />
-                                        <option name="name" value="Pobierz wszysktie bronie postaci dla Admina" />
-                                        <option name="sortWeight" value="3000000" />
-                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/games/cpRed/characters/weapons/all" />
-                                      </requestState>
-                                      <requestState>
-                                        <option name="body">
-                                          <bodyState>
-                                            <option name="raw" value="{&#10;  dmg: 10,&#10;  magazineCapacity: 100,&#10;  numberOfAttacks: 4,&#10;  handType: 3,&#10;  isHidden: true,&#10;  quality: &quot;STANDARD&quot;, // &quot;POOR&quot;, &quot;STANDARD&quot;, &quot;EXCELLENT&quot;&#10;  status: &quot;EQUIPPED&quot;, // &quot;STORED&quot;, &quot;EQUIPPED&quot;&#10;  description: &quot;Taka giwera że ja pie....&quot;,&#10;}" />
-                                            <option name="type" value="JSON" />
-                                          </bodyState>
-                                        </option>
-                                        <option name="description" value="Pozwala modyfikować parametry broni przypisanej do użytkownika" />
-                                        <option name="id" value="c7731506-7da3-48c3-b33a-f641c31b2c64" />
-                                        <option name="method" value="PUT" />
-                                        <option name="name" value="Modyfikuj broń postaci" />
-                                        <option name="sortWeight" value="4000000" />
-                                        <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/weapons/update/1" />
-                                      </requestState>
-                                      <requestState>
-                                        <option name="description" value="Usuwa powiązanie wybranej po ID broni z userem" />
-                                        <option name="id" value="a13c4591-fb07-46af-a557-ca9b6a50970d" />
-                                        <option name="method" value="DELETE" />
-                                        <option name="name" value="Usuń powiązanie broni z postacią" />
-                                        <option name="sortWeight" value="5000000" />
-                                        <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/weapons/delete/1" />
-                                      </requestState>
-                                    </list>
-                                  </option>
                                   <option name="sortWeight" value="3000000" />
                                 </folderState>
                                 <folderState>

--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -1949,7 +1949,7 @@
                                             <requestState>
                                               <option name="body">
                                                 <bodyState>
-                                                  <option name="raw" value="{&#10;  baseWeaponId: 2,&#10;  characterId: 1,&#10;  status: &quot;EQUIPPED&quot; // &quot;STORED&quot;, &quot;EQUIPPED&quot;&#10;}" />
+                                                  <option name="raw" value="{&#10;  baseCustomWeaponId: 2,&#10;  characterId: 1,&#10;  status: &quot;EQUIPPED&quot; // &quot;STORED&quot;, &quot;EQUIPPED&quot;&#10;}" />
                                                   <option name="type" value="JSON" />
                                                 </bodyState>
                                               </option>

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomWeapon/AddCharacterCustomWeaponRequest.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomWeapon/AddCharacterCustomWeaponRequest.java
@@ -1,0 +1,17 @@
+package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterCustomWeapon;
+
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterItem.CpRedCharacterItemStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AddCharacterCustomWeaponRequest {
+    private Long baseCustomWeaponId;
+    private Long characterId;
+    private CpRedCharacterItemStatus status;
+}

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomWeapon/CpRedCharacterCustomWeapon.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomWeapon/CpRedCharacterCustomWeapon.java
@@ -33,19 +33,19 @@ public class CpRedCharacterCustomWeapon {
             referencedColumnName = "id",
             nullable = false
     )
-    private CpRedCustomWeapons baseWeaponId;
+    private CpRedCustomWeapons baseCustomWeapon;
     @ManyToOne
     @JoinColumn(
             name = "character_id",
             referencedColumnName = "id",
             nullable = false
     )
-    private CpRedCharacters characterId;
-    private int dmg;
-    private int magazineCapacity;
-    private short numberOfAttacks;
+    private CpRedCharacters character;
+    private Integer dmg;
+    private Integer magazineCapacity;
+    private Short numberOfAttacks;
     private Short handType;
-    private boolean isHidden;
+    private Boolean isHidden;
     @Enumerated(EnumType.STRING)
     private CpRedItemsQuality quality;
     @Enumerated(EnumType.STRING)

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomWeapon/CpRedCharacterCustomWeaponController.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomWeapon/CpRedCharacterCustomWeaponController.java
@@ -1,0 +1,43 @@
+package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterCustomWeapon;
+
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterWeapon.AddCharacterWeaponRequest;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterWeapon.UpdateCharacterWeaponRequest;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping(path = "api/v1/authorized")
+@AllArgsConstructor
+public class CpRedCharacterCustomWeaponController {
+    private final CpRedCharacterCustomWeaponService cpRedCharacterCustomWeaponService;
+
+    // ============ User methods ============
+    @GetMapping(path = "/games/cpRed/characters/customWeapons/{characterId}")
+    public Map<String, Object> getCharacterCustomWeapons(@PathVariable("characterId")Long characterId) {
+        return cpRedCharacterCustomWeaponService.getCharacterCustomWeapons(characterId);
+    }
+
+    @PostMapping(path = "/games/cpRed/characters/customWeapons/create")
+    public Map<String, Object> createCharacterCustomWeapon(@RequestBody AddCharacterCustomWeaponRequest addCharacterCustomWeaponRequest) {
+        return cpRedCharacterCustomWeaponService.createCharacterCustomWeapon(addCharacterCustomWeaponRequest);
+    }
+
+    @PutMapping(path = "/games/cpRed/characters/customWeapons/update/{characterCustomWeaponId}")
+    public Map<String, Object> updateCharacterCustomWeapon(@PathVariable("characterCustomWeaponId") Long characterCustomWeaponId,
+                                                     @RequestBody UpdateCharacterCustomWeaponRequest updateCharacterCustomWeaponRequest) {
+        return cpRedCharacterCustomWeaponService.updateCharacterCustomWeapon(characterCustomWeaponId, updateCharacterCustomWeaponRequest);
+    }
+
+    @DeleteMapping(path = "/games/cpRed/characters/customWeapons/delete/{characterCustomWeaponId}")
+    public Map<String, Object> deleteCharacterCustomWeapon(@PathVariable("characterCustomWeaponId") Long characterCustomWeaponId) {
+        return cpRedCharacterCustomWeaponService.deleteCharacterCustomWeapon(characterCustomWeaponId);
+    }
+
+    // ============ Admin methods ============
+    @GetMapping(path = "/admin/games/cpRed/characters/customWeapons/all")
+    public Map<String, Object> getAllCharacterCustomWeapons() {
+        return cpRedCharacterCustomWeaponService.getAllCharacterCustomWeapons();
+    }
+}

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomWeapon/CpRedCharacterCustomWeaponDTO.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomWeapon/CpRedCharacterCustomWeaponDTO.java
@@ -8,7 +8,8 @@ import lombok.ToString;
 @AllArgsConstructor
 @ToString
 public class CpRedCharacterCustomWeaponDTO {
-    private Long baseWeaponId;
+    private Long id;
+    private Long baseCustomWeaponId;
     private Long characterId;
     private int dmg;
     private int magazineCapacity;

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomWeapon/CpRedCharacterCustomWeaponRepository.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomWeapon/CpRedCharacterCustomWeaponRepository.java
@@ -1,8 +1,14 @@
 package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterCustomWeapon;
 
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharacters;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterWeapon.CpRedCharacterWeapon;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Arrays;
+import java.util.List;
+
 @Repository
 public interface CpRedCharacterCustomWeaponRepository extends JpaRepository<CpRedCharacterCustomWeapon, Long> {
+    List<CpRedCharacterCustomWeapon> findAllByCharacter(CpRedCharacters character);
 }

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomWeapon/CpRedCharacterCustomWeaponService.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomWeapon/CpRedCharacterCustomWeaponService.java
@@ -99,7 +99,7 @@ public class CpRedCharacterCustomWeaponService {
                     throw new ResourceNotFoundException("Zalogowany użytkownik nie jest GM-em w tej grze ani nie jest właścicielem postaci.");
                 }
             } else {
-                throw new ResourceNotFoundException("Tylko GM może zmieniać bronie postaci NPC.");
+                throw new ResourceNotFoundException("Tylko GM może dodawać customowe bronie postaci NPC.");
             }
         }
         // Czy gra jest aktywna
@@ -165,7 +165,7 @@ public class CpRedCharacterCustomWeaponService {
                     throw new ResourceNotFoundException("Zalogowany użytkownik nie jest GM-em w tej grze ani nie jest właścicielem postaci.");
                 }
             } else {
-                throw new ResourceNotFoundException("Tylko GM może zmieniać bronie postaci NPC.");
+                throw new ResourceNotFoundException("Tylko GM może zmieniać customowe bronie postaci NPC.");
             }
         }
 
@@ -267,7 +267,7 @@ public class CpRedCharacterCustomWeaponService {
                     throw new ResourceNotFoundException("Zalogowany użytkownik nie jest GM-em w tej grze ani nie jest właścicielem postaci.");
                 }
             } else {
-                throw new ResourceNotFoundException("Tylko GM może zmieniać bronie postaci NPC.");
+                throw new ResourceNotFoundException("Tylko GM może usuwać customowe bronie postaci NPC.");
             }
         }
 

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomWeapon/CpRedCharacterCustomWeaponService.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomWeapon/CpRedCharacterCustomWeaponService.java
@@ -1,4 +1,4 @@
-package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterWeapon;
+package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterCustomWeapon;
 
 import dev.goral.rpghandyhelper.game.Game;
 import dev.goral.rpghandyhelper.game.GameRepository;
@@ -9,10 +9,8 @@ import dev.goral.rpghandyhelper.game.gameUsers.GameUsersRole;
 import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharacters;
 import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharactersRepository;
 import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharactersType;
-import dev.goral.rpghandyhelper.rpgSystems.cpRed.items.CpRedItemsQuality;
-import dev.goral.rpghandyhelper.rpgSystems.cpRed.manual.stats.CpRedStats;
-import dev.goral.rpghandyhelper.rpgSystems.cpRed.manual.weapons.CpRedWeapons;
-import dev.goral.rpghandyhelper.rpgSystems.cpRed.manual.weapons.CpRedWeaponsRepository;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.custom.customWeapons.CpRedCustomWeapons;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.custom.customWeapons.CpRedCustomWeaponsRepository;
 import dev.goral.rpghandyhelper.security.CustomReturnables;
 import dev.goral.rpghandyhelper.security.exceptions.ResourceNotFoundException;
 import dev.goral.rpghandyhelper.user.User;
@@ -21,8 +19,6 @@ import lombok.AllArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RequestBody;
-
 
 import java.util.List;
 import java.util.Map;
@@ -30,58 +26,58 @@ import java.util.Objects;
 
 @Service
 @AllArgsConstructor
-public class CpRedCharacterWeaponService {
-    private final CpRedCharacterWeaponRepository cpRedCharacterWeaponRepository;
+public class CpRedCharacterCustomWeaponService {
+    private final CpRedCharacterCustomWeaponRepository cpRedCharacterCustomWeaponRepository;
     private final UserRepository userRepository;
     private final CpRedCharactersRepository cpRedCharactersRepository;
     private final GameRepository gameRepository;
     private final GameUsersRepository gameUsersRepository;
-    private final CpRedWeaponsRepository cpRedWeaponsRepository;
+    private final CpRedCustomWeaponsRepository cpRedCustomWeaponsRepository;
 
-    public Map<String, Object> getCharacterWeapons(Long characterId) {
+    public Map<String, Object> getCharacterCustomWeapons(Long characterId){
         CpRedCharacters character = cpRedCharactersRepository.findById(characterId)
                 .orElseThrow(() -> new ResourceNotFoundException("Postać o podanym ID nie została znaleziona."));
-        List<CpRedCharacterWeaponDTO> characterWeapons = cpRedCharacterWeaponRepository.findAllByCharacter(character)
+        List<CpRedCharacterCustomWeaponDTO> characterCustomWeapons = cpRedCharacterCustomWeaponRepository.findAllByCharacter(character)
                 .stream()
-                .map(weapons -> new CpRedCharacterWeaponDTO(
-                        weapons.getId(),
-                        weapons.getBaseWeapon().getId(),
-                        weapons.getCharacter().getId(),
-                        weapons.getDmg(),
-                        weapons.getMagazineCapacity(),
-                        weapons.getNumberOfAttacks(),
-                        weapons.getHandType(),
-                        weapons.getIsHidden(),
-                        weapons.getQuality().toString(),
-                        weapons.getStatus().toString(),
-                        weapons.getDescription()
+                .map(weapons -> new CpRedCharacterCustomWeaponDTO(
+                                weapons.getId(),
+                                weapons.getBaseCustomWeapon().getId(),
+                                weapons.getCharacter().getId(),
+                                weapons.getDmg(),
+                                weapons.getMagazineCapacity(),
+                                weapons.getNumberOfAttacks(),
+                                weapons.getHandType(),
+                                weapons.getIsHidden(),
+                                weapons.getQuality().toString(),
+                                weapons.getStatus().toString(),
+                                weapons.getDescription()
                         )
                 )
                 .toList();
-        Map<String, Object> response = CustomReturnables.getOkResponseMap("Bronie postaci pobrane pomyślnie");
-        response.put("characterWeapons", characterWeapons);
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Customowe bronie postaci pobrane pomyślnie");
+        response.put("characterCustomWeapons", characterCustomWeapons);
         return response;
     }
 
-    public Map<String, Object> createCharacterWeapon(AddCharacterWeaponRequest addCharacterWeaponRequest) {
+    public Map<String, Object> createCharacterCustomWeapon(AddCharacterCustomWeaponRequest addCharacterCustomWeaponRequest) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String currentUsername = authentication.getName();
         User currentUser = userRepository.findByUsername(currentUsername)
                 .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
 
         // Czy podano wszystkie wymagane pola w request
-        if (addCharacterWeaponRequest.getBaseWeaponId() == null ||
-                addCharacterWeaponRequest.getCharacterId() == null ||
-                addCharacterWeaponRequest.getStatus() == null) {
+        if (addCharacterCustomWeaponRequest.getBaseCustomWeaponId() == null ||
+                addCharacterCustomWeaponRequest.getCharacterId() == null ||
+                addCharacterCustomWeaponRequest.getStatus() == null) {
             throw new IllegalArgumentException("Wszystkie pola muszą być wypełnione.");
         }
 
         // Czy istnieje character o podanym ID
-        CpRedCharacters character = cpRedCharactersRepository.findById(addCharacterWeaponRequest.getCharacterId())
+        CpRedCharacters character = cpRedCharactersRepository.findById(addCharacterCustomWeaponRequest.getCharacterId())
                 .orElseThrow(() -> new ResourceNotFoundException("Postać o podanym ID nie została znaleziona."));
 
         // Czy istnieje broń o podanym ID
-        CpRedWeapons weapon = cpRedWeaponsRepository.findById(addCharacterWeaponRequest.getBaseWeaponId())
+        CpRedCustomWeapons weapon = cpRedCustomWeaponsRepository.findById(addCharacterCustomWeaponRequest.getBaseCustomWeaponId())
                 .orElseThrow(() -> new ResourceNotFoundException("Broń o podanym ID nie została znaleziona."));
 
         Game game = gameRepository.findById(character.getGame().getId())
@@ -90,6 +86,11 @@ public class CpRedCharacterWeaponService {
         // Czy użytkownik należy do gry, do której należy postać
         GameUsers gameUsers = gameUsersRepository.findGameUsersByUserIdAndGameId(currentUser.getId(), game.getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Nie należysz do gry powiązanej z podaną postacią."));
+
+        // Czy postać należy do gry, do której jest przypisana customowa broń
+        if (!Objects.equals(character.getGame().getId(), weapon.getGameId().getId())) {
+            throw new ResourceNotFoundException("Postać nie należy do gry, do której jest przypisana customowa broń.");
+        }
 
         // Czy ktoś chce zmieniać swoją postać lub jest GM-em w tej grze
         if (gameUsers.getRole() != GameUsersRole.GAMEMASTER){
@@ -107,7 +108,7 @@ public class CpRedCharacterWeaponService {
         }
 
         // Tworzenie nowej klasy postaci
-        CpRedCharacterWeapon newCharacterWeapon = new CpRedCharacterWeapon(
+        CpRedCharacterCustomWeapon newCharacterCustomWeapon = new CpRedCharacterCustomWeapon(
                 null,
                 weapon,
                 character,
@@ -117,31 +118,32 @@ public class CpRedCharacterWeaponService {
                 weapon.getHandType(),
                 weapon.isHidden(),
                 weapon.getQuality(),
-                addCharacterWeaponRequest.getStatus(),
+                addCharacterCustomWeaponRequest.getStatus(),
                 weapon.getDescription()
         );
 
-        cpRedCharacterWeaponRepository.save(newCharacterWeapon);
-        return CustomReturnables.getOkResponseMap("Broń została dodana do postaci");
+        cpRedCharacterCustomWeaponRepository.save(newCharacterCustomWeapon);
+
+        return CustomReturnables.getOkResponseMap("Customowa broń została dodana do postaci");
     }
 
-    public Map<String, Object> updateCharacterWeapon(Long characterWeaponId,
-                                                     UpdateCharacterWeaponRequest updateCharacterWeaponRequest) {
+    public Map<String, Object> updateCharacterCustomWeapon(Long characterCustomWeaponId,
+                                                           UpdateCharacterCustomWeaponRequest updateCharacterCustomWeaponRequest) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String currentUsername = authentication.getName();
         User currentUser = userRepository.findByUsername(currentUsername)
                 .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
 
         // Czy istnieje broń postaci o podanym ID
-        CpRedCharacterWeapon characterWeaponToUpdate = cpRedCharacterWeaponRepository.findById(characterWeaponId)
+        CpRedCharacterCustomWeapon characterCustomWeaponToUpdate = cpRedCharacterCustomWeaponRepository.findById(characterCustomWeaponId)
                 .orElseThrow(() -> new ResourceNotFoundException("Broń postaci o podanym ID nie została znaleziona."));
 
         // Czy istnieje character o podanym ID
-        CpRedCharacters character = cpRedCharactersRepository.findById(characterWeaponToUpdate.getCharacter().getId())
+        CpRedCharacters character = cpRedCharactersRepository.findById(characterCustomWeaponToUpdate.getCharacter().getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Postać o podanym ID nie została znaleziona."));
 
         // Czy istnieje broń o podanym ID
-        CpRedWeapons weapon = cpRedWeaponsRepository.findById(characterWeaponToUpdate.getBaseWeapon().getId())
+        CpRedCustomWeapons weapon = cpRedCustomWeaponsRepository.findById(characterCustomWeaponToUpdate.getBaseCustomWeapon().getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Broń o podanym ID nie została znaleziona."));
 
         Game game = gameRepository.findById(character.getGame().getId())
@@ -150,6 +152,11 @@ public class CpRedCharacterWeaponService {
         // Czy użytkownik należy do gry, do której należy postać
         GameUsers gameUsers = gameUsersRepository.findGameUsersByUserIdAndGameId(currentUser.getId(), game.getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Nie należysz do gry powiązanej z podaną postacią."));
+
+        // Czy postać należy do gry, do której jest przypisana customowa broń
+        if (!Objects.equals(character.getGame().getId(), weapon.getGameId().getId())) {
+            throw new ResourceNotFoundException("Postać nie należy do gry, do której jest przypisana customowa broń.");
+        }
 
         // Czy ktoś chce zmieniać swoją postać lub jest GM-em w tej grze
         if (gameUsers.getRole() != GameUsersRole.GAMEMASTER){
@@ -168,82 +175,82 @@ public class CpRedCharacterWeaponService {
         }
 
         // Sprawdzenie dmg
-        if (updateCharacterWeaponRequest.getDmg() != null) {
-            if (updateCharacterWeaponRequest.getDmg() < 0) {
+        if (updateCharacterCustomWeaponRequest.getDmg() != null) {
+            if (updateCharacterCustomWeaponRequest.getDmg() < 0) {
                 throw new IllegalArgumentException("Wartość obrażeń nie może być mniejsza niż 0.");
             }
-            characterWeaponToUpdate.setDmg(updateCharacterWeaponRequest.getDmg());
+            characterCustomWeaponToUpdate.setDmg(updateCharacterCustomWeaponRequest.getDmg());
         }
 
         // Sprawdzenie magazineCapacity
-        if (updateCharacterWeaponRequest.getMagazineCapacity() != null) {
-            if (updateCharacterWeaponRequest.getMagazineCapacity() < 0) {
+        if (updateCharacterCustomWeaponRequest.getMagazineCapacity() != null) {
+            if (updateCharacterCustomWeaponRequest.getMagazineCapacity() < 0) {
                 throw new IllegalArgumentException("Pojemność magazynka nie może być mniejsza niż 0.");
             }
-            characterWeaponToUpdate.setMagazineCapacity(updateCharacterWeaponRequest.getMagazineCapacity());
+            characterCustomWeaponToUpdate.setMagazineCapacity(updateCharacterCustomWeaponRequest.getMagazineCapacity());
         }
 
         // Sprawdzenie numberOfAttacks
-        if (updateCharacterWeaponRequest.getNumberOfAttacks() != null) {
-            if (updateCharacterWeaponRequest.getNumberOfAttacks() < 0) {
+        if (updateCharacterCustomWeaponRequest.getNumberOfAttacks() != null) {
+            if (updateCharacterCustomWeaponRequest.getNumberOfAttacks() < 0) {
                 throw new IllegalArgumentException("Liczba ataków nie może być mniejsza niż 0.");
             }
-            characterWeaponToUpdate.setNumberOfAttacks(updateCharacterWeaponRequest.getNumberOfAttacks());
+            characterCustomWeaponToUpdate.setNumberOfAttacks(updateCharacterCustomWeaponRequest.getNumberOfAttacks());
         }
 
         // Sprawdzenie handType
-        if (updateCharacterWeaponRequest.getHandType() != null) {
-            if (updateCharacterWeaponRequest.getHandType() < 0) {
+        if (updateCharacterCustomWeaponRequest.getHandType() != null) {
+            if (updateCharacterCustomWeaponRequest.getHandType() < 0) {
                 throw new IllegalArgumentException("Typ ręki nie może być mniejszy niż 0.");
             }
-            characterWeaponToUpdate.setHandType(updateCharacterWeaponRequest.getHandType());
+            characterCustomWeaponToUpdate.setHandType(updateCharacterCustomWeaponRequest.getHandType());
         }
 
         // Sprawdzenie isHidden
-        if (updateCharacterWeaponRequest.getIsHidden() != null) {
-            characterWeaponToUpdate.setIsHidden(updateCharacterWeaponRequest.getIsHidden());
+        if (updateCharacterCustomWeaponRequest.getIsHidden() != null) {
+            characterCustomWeaponToUpdate.setIsHidden(updateCharacterCustomWeaponRequest.getIsHidden());
         }
 
         // Sprawdzenie quality
-        if (updateCharacterWeaponRequest.getQuality() != null) {
-            characterWeaponToUpdate.setQuality(updateCharacterWeaponRequest.getQuality());
+        if (updateCharacterCustomWeaponRequest.getQuality() != null) {
+            characterCustomWeaponToUpdate.setQuality(updateCharacterCustomWeaponRequest.getQuality());
         }
 
         // Sprawdzenie status
-        if (updateCharacterWeaponRequest.getStatus() != null) {
-            characterWeaponToUpdate.setStatus(updateCharacterWeaponRequest.getStatus());
+        if (updateCharacterCustomWeaponRequest.getStatus() != null) {
+            characterCustomWeaponToUpdate.setStatus(updateCharacterCustomWeaponRequest.getStatus());
         }
 
         // Sprawdzenie opisu
-        if (updateCharacterWeaponRequest.getDescription() != null) {
-            if (updateCharacterWeaponRequest.getDescription().length() > 500) {
+        if (updateCharacterCustomWeaponRequest.getDescription() != null) {
+            if (updateCharacterCustomWeaponRequest.getDescription().length() > 500) {
                 throw new IllegalArgumentException("Opis nie może być dłuższy niż 500 znaków.");
             }
-            characterWeaponToUpdate.setDescription(updateCharacterWeaponRequest.getDescription());
+            characterCustomWeaponToUpdate.setDescription(updateCharacterCustomWeaponRequest.getDescription());
         }
 
         // Zapisanie zmodyfikowanej broni postaci
-        cpRedCharacterWeaponRepository.save(characterWeaponToUpdate);
-
-        return CustomReturnables.getOkResponseMap("Broń postaci została pomyślnie zmodyfikowana");
+        cpRedCharacterCustomWeaponRepository.save(characterCustomWeaponToUpdate);
+        
+        return CustomReturnables.getOkResponseMap("Customowa broń postaci została pomyślnie zmodyfikowana");
     }
 
-    public Map<String, Object> deleteCharacterWeapon(Long characterWeaponId) {
+    public Map<String, Object> deleteCharacterCustomWeapon(Long characterCustomWeaponId) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String currentUsername = authentication.getName();
         User currentUser = userRepository.findByUsername(currentUsername)
                 .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
 
         // Czy istnieje broń postaci o podanym ID
-        CpRedCharacterWeapon characterWeapon = cpRedCharacterWeaponRepository.findById(characterWeaponId)
+        CpRedCharacterCustomWeapon characterCustomWeapon = cpRedCharacterCustomWeaponRepository.findById(characterCustomWeaponId)
                 .orElseThrow(() -> new ResourceNotFoundException("Broń postaci o podanym ID nie została znaleziona."));
 
         // Czy istnieje character o podanym ID
-        CpRedCharacters character = cpRedCharactersRepository.findById(characterWeapon.getCharacter().getId())
+        CpRedCharacters character = cpRedCharactersRepository.findById(characterCustomWeapon.getCharacter().getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Postać o podanym ID nie została znaleziona."));
 
         // Czy istnieje broń o podanym ID
-        CpRedWeapons weapon = cpRedWeaponsRepository.findById(characterWeapon.getBaseWeapon().getId())
+        CpRedCustomWeapons weapon = cpRedCustomWeaponsRepository.findById(characterCustomWeapon.getBaseCustomWeapon().getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Broń o podanym ID nie została znaleziona."));
 
         Game game = gameRepository.findById(character.getGame().getId())
@@ -269,15 +276,15 @@ public class CpRedCharacterWeaponService {
             throw new IllegalStateException("Gra do której należy postać nie jest aktywna.");
         }
 
-        cpRedCharacterWeaponRepository.deleteById(characterWeaponId);
-
-        return CustomReturnables.getOkResponseMap("Broń postaci została pomyślnie usunięta");
+        cpRedCharacterCustomWeaponRepository.deleteById(characterCustomWeaponId);
+        
+        return CustomReturnables.getOkResponseMap("Customowa broń postaci została pomyślnie usunięta");
     }
 
-    public Map<String, Object> getAllCharacterWeapons() {
-        List<CpRedCharacterWeapon> allCharacterWeapons = cpRedCharacterWeaponRepository.findAll();
-        Map<String, Object> response = CustomReturnables.getOkResponseMap("Wszystkie bronie postaci pobrane pomyślnie");
-        response.put("allCharacterWeapons", allCharacterWeapons);
+    public Map<String, Object> getAllCharacterCustomWeapons(){
+        List<CpRedCharacterCustomWeapon> allCharacterCustomWeapons = cpRedCharacterCustomWeaponRepository.findAll();
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Wszystkie customowe bronie postaci pobrane pomyślnie");
+        response.put("allCharacterCustomWeapons", allCharacterCustomWeapons);
         return response;
     }
 }

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomWeapon/UpdateCharacterCustomWeaponRequest.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomWeapon/UpdateCharacterCustomWeaponRequest.java
@@ -1,0 +1,25 @@
+package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterCustomWeapon;
+
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterItem.CpRedCharacterItemStatus;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.items.CpRedItemsQuality;
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateCharacterCustomWeaponRequest {
+    private Integer dmg;
+    private Integer magazineCapacity;
+    private Short numberOfAttacks;
+    private Short handType;
+    private Boolean isHidden;
+    private CpRedItemsQuality quality;
+    private CpRedCharacterItemStatus status;
+    @Column(length = 500)
+    private String description;
+}

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterWeapon/CpRedCharacterWeaponService.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterWeapon/CpRedCharacterWeaponService.java
@@ -98,7 +98,7 @@ public class CpRedCharacterWeaponService {
                     throw new ResourceNotFoundException("Zalogowany użytkownik nie jest GM-em w tej grze ani nie jest właścicielem postaci.");
                 }
             } else {
-                throw new ResourceNotFoundException("Tylko GM może zmieniać bronie postaci NPC.");
+                throw new ResourceNotFoundException("Tylko GM może dodawać bronie postaci NPC.");
             }
         }
         // Czy gra jest aktywna
@@ -260,7 +260,7 @@ public class CpRedCharacterWeaponService {
                     throw new ResourceNotFoundException("Zalogowany użytkownik nie jest GM-em w tej grze ani nie jest właścicielem postaci.");
                 }
             } else {
-                throw new ResourceNotFoundException("Tylko GM może zmieniać bronie postaci NPC.");
+                throw new ResourceNotFoundException("Tylko GM może usuwać bronie postaci NPC.");
             }
         }
 


### PR DESCRIPTION
# Info dla testerów
## Kontekst
Encja bardzo podobna do poprzedniej. Odpowiada za połączenie customowej broni z postacią. Przy tworzeniu wybierasz tak naprawdę templatke i ustawiasz parametry broni na stockowe, dalej możesz je edytować. Można mieć kilka takich samych broni. Istotną różnicą względem poprzedniej encji jest to, że przy dodaniu jest też sprawdzane, czy postać jest z tej samej gry co customowa broń broń.

Każdy obiekt zawiera 11 pól:

- `id` - wiadomo, jest to indeks połączenia
- `baseCustomWeapon` - bazowa customowa broń
- `character` - powiązana postać (posiadacz broni)
- `dmg` - ilość rzutów k6 dla danej broni ( >= 0)
- `magazineCapacity` - pojemność magazynka ( >= 0)
- `numberOfAttacks` - ilość ataków w jednej turze ( >= 0)
- `handType` - ile rąk potrzeba żeby ją obsługiwać ( >= 0)
- `isHidden` - czy jest możliwa do ukrycia (true/false)
- `quality` - jakość broni (POOR / STANDARD / EXCELLENT)
- `status` - gdzie znajduje się broń (STORED / EQUIPPED)
- `description` - opis broni

Uprawnieniowo tak samo jak w poprzedniej PRce: Dodać/ modyfikować/usunąć broń postaci może tylko GM gry do której przypisana jest postać lub właściciel postaci.

## Endpointy
- `http://localhost:8888/api/v1/authorized/games/cpRed/characters/customWeapons/create` - dodaje nowe powiązanie między customową bronią i postacią, wybieramy tylko postać, customową broń i status. Reszta danych jest kopiowana z templatki wybranej broni. 
- `http://localhost:8888/api/v1/authorized/games/cpRed/characters/customWeapons/*` - zwraca listę customowych broni dla podanej po id postaci
- `http://localhost:8888/api/v1/authorized/admin/games/cpRed/characters/customWeapons/all` - zwraca listę wszystkich powiązań między customową bronią i postacią
- `http://localhost:8888/api/v1/authorized/games/cpRed/characters/customWeapons/update/*` - modyfikuje podane parametry customowej broni, nie da się modyfikować postaci ani broni
- `http://localhost:8888/api/v1/authorized/games/cpRed/characters/customWeapons/delete/*` - usuwa wybrane po id połączenie customowej broni

## Na koniec
Standardowo na branchu są zapytania w Jetclienice zrobione, a na discordzie macie zmodyfikowany Config dla tej PRki.
Będziemy bardzo wdzięczni za pośpiech bo ta PRka blokuje prace nad `CharacterWeaponAmmunition` i `CharacteWeaponMod`.

Miłego testowania ;)
@Kosiorny @szxxlc 
