### PR TITLE
CpRedCharacterLifePath

### DIFF
--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -2119,6 +2119,78 @@
                                 <folderState>
                                   <option name="id" value="a85f73b2-88dd-4094-aefb-03bad39725ba" />
                                   <option name="name" value="LifePaths" />
+                                  <option name="requests">
+                                    <list>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  &quot;characterId&quot;: 2,&#10;  &quot;cultureOfOrigin&quot;: &quot;Polish&quot;,&#10;  &quot;yourCharacter&quot;: &quot;pleasant&quot;,&#10;  &quot;clothingAndStyle&quot;: &quot;punk&quot;,&#10;  &quot;hair&quot;: &quot;bald&quot;,&#10;  &quot;mostValue&quot;: &quot;money&quot;,&#10;  &quot;relationships&quot;: &quot;girlfriend&quot;,&#10;  &quot;mostImportantPerson&quot;: &quot;mother&quot;,&#10;  &quot;mostImportantItem&quot;: &quot;ring&quot;,&#10;  &quot;familyBackground&quot;: &quot;poor family&quot;,&#10;  &quot;familyEnvironment&quot;: &quot;gang&quot;,&#10;  &quot;familyCrisis&quot;: &quot; death of father&quot;,&#10;  &quot;lifeGoals&quot;: &quot;to become rich&quot;&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Dodaje ścieżkę" />
+                                        <option name="id" value="d36bdc3f-4515-4048-b044-12804270bb77" />
+                                        <option name="method" value="POST" />
+                                        <option name="name" value="Dodaj ścieżkę życiową" />
+                                        <option name="sortWeight" value="1000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/lifepaths/add" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="body">
+                                          <bodyState>
+                                            <option name="raw" value="{&#10;  &quot;characterId&quot;: 2,&#10;  &quot;cultureOfOrigin&quot;: &quot;English&quot;,&#10;  &quot;yourCharacter&quot;: &quot;wierd&quot;,&#10;  &quot;clothingAndStyle&quot;: &quot;corporate&quot;,&#10;  &quot;hair&quot;: &quot;long, blonde&quot;,&#10;  &quot;mostValue&quot;: &quot;church&quot;,&#10;  &quot;relationships&quot;: &quot;friend&quot;,&#10;  &quot;mostImportantPerson&quot;: &quot;dad&quot;,&#10;  &quot;mostImportantItem&quot;: &quot;knife&quot;,&#10;  &quot;familyBackground&quot;: &quot;rich family&quot;,&#10;  &quot;familyEnvironment&quot;: &quot;wealthy&quot;,&#10;  &quot;familyCrisis&quot;: &quot; death of mother&quot;,&#10;  &quot;lifeGoals&quot;: &quot;to become doctor&quot;&#10;}" />
+                                            <option name="type" value="JSON" />
+                                          </bodyState>
+                                        </option>
+                                        <option name="description" value="Zmienia dane" />
+                                        <option name="id" value="65547ad7-a77b-429a-b50e-5fcc7c2add7b" />
+                                        <option name="method" value="PUT" />
+                                        <option name="name" value="Modyfikuj ścieżkę życiową" />
+                                        <option name="sortWeight" value="2000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/lifepaths/update/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca po unikalnym Id" />
+                                        <option name="id" value="783a2f4a-25f8-446a-a35c-ab9dcb8b762e" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Zwróć ścieżkę po Id" />
+                                        <option name="sortWeight" value="3000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/lifepaths/1" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca wszystkie ścieżki wszystkich kart postaci" />
+                                        <option name="id" value="84f807a6-a6e4-42b1-a577-5b5018a69e49" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Zwróć wszystkie ścieżki" />
+                                        <option name="sortWeight" value="4000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/lifepaths/all" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca po unikalnym characterId" />
+                                        <option name="id" value="b8ca814b-9510-486e-8236-d8f60aac69cb" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Zwróć ścieżkę po characterId" />
+                                        <option name="sortWeight" value="6000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/lifepaths/character/2" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Zwraca obiekty" />
+                                        <option name="id" value="6c528490-7162-4916-9f96-31336ef3161a" />
+                                        <option name="method" value="GET" />
+                                        <option name="name" value="Zwróć wszystkie ścieżki dla admina" />
+                                        <option name="sortWeight" value="7000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/admin/rpgSystems/cpRed/character/lifepaths/all" />
+                                      </requestState>
+                                      <requestState>
+                                        <option name="description" value="Usuwa ścieżkę" />
+                                        <option name="id" value="b71d6581-b46f-47bf-ae63-cc7520345aaf" />
+                                        <option name="method" value="DELETE" />
+                                        <option name="name" value="Usuń ścieżkę" />
+                                        <option name="sortWeight" value="8000000" />
+                                        <option name="url" value="http://localhost:8888/api/v1/authorized/rpgSystems/cpRed/character/lifepaths/delete/1" />
+                                      </requestState>
+                                    </list>
+                                  </option>
                                   <option name="sortWeight" value="5000000" />
                                 </folderState>
                                 <folderState>

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterLifePaths/CpRedCharacterLIfePathsController.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterLifePaths/CpRedCharacterLIfePathsController.java
@@ -1,0 +1,52 @@
+package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterLifePaths;
+
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterLifePaths.CpRedCharacterLifePathsRequest;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterLifePaths.CpRedCharacterLifePathsService;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController 
+@RequestMapping(path = "api/v1/authorized")
+@AllArgsConstructor
+public class CpRedCharacterLIfePathsController {
+    private final CpRedCharacterLifePathsService cpRedCharacterLifePathsService;
+
+
+    @GetMapping(path = "/rpgSystems/cpRed/character/lifepaths/all")
+    public Map<String, Object> getAllLifePaths() {
+        return cpRedCharacterLifePathsService.getAllLifePaths();
+    }
+
+    @GetMapping(path = "/rpgSystems/cpRed/character/lifepaths/{pathId}")
+    public Map<String, Object> getLifePathById(@PathVariable("pathId") Long pathId) {
+        return cpRedCharacterLifePathsService.getLifePathById(pathId);
+    }
+
+    @GetMapping(path = "/rpgSystems/cpRed/character/lifepaths/character/{characterId}")
+    public Map<String, Object> getLifePathByCharacterId(@PathVariable("characterId") Long characterId) {
+        return cpRedCharacterLifePathsService.getLifePathByCharacterId(characterId);
+    }
+
+    @GetMapping(path = "/admin/rpgSystems/cpRed/character/lifepaths/all")
+    public Map<String, Object> getAllLifePathsForAdmin() {
+        return cpRedCharacterLifePathsService.getAllLifePathsForAdmin();
+    }
+
+    @PostMapping(path = "/rpgSystems/cpRed/character/lifepaths/add")
+    public Map<String, Object> addLifePath(@RequestBody CpRedCharacterLifePathsRequest cpRedCharacterLifePaths) {
+        return cpRedCharacterLifePathsService.addLifePath(cpRedCharacterLifePaths);
+    }
+
+    @DeleteMapping(path = "/rpgSystems/cpRed/character/lifepaths/delete/{pathId}")
+    public Map<String, Object> deleteLifePath(@PathVariable("pathId") Long pathId) {
+        return cpRedCharacterLifePathsService.deleteLifePath(pathId);
+    }
+
+    @PutMapping(path = "/rpgSystems/cpRed/character/lifepaths/update/{pathId}")
+    public Map<String, Object> updateLifePath(@PathVariable("pathId") Long pathId,
+                                               @RequestBody CpRedCharacterLifePathsRequest cpRedCharacterLifePaths) {
+        return cpRedCharacterLifePathsService.updateLifePath(pathId, cpRedCharacterLifePaths);
+    }
+}

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterLifePaths/CpRedCharacterLifePathsRepository.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterLifePaths/CpRedCharacterLifePathsRepository.java
@@ -1,8 +1,13 @@
 package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterLifePaths;
 
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharacters;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CpRedCharacterLifePathsRepository extends JpaRepository<CpRedCharacterLifePaths, Long> {
+    List<CpRedCharacterLifePaths> findAllByCharacterId_Id(Long characterId);
+    Boolean existsByCharacterId(CpRedCharacters character);
 }

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterLifePaths/CpRedCharacterLifePathsRequest.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterLifePaths/CpRedCharacterLifePathsRequest.java
@@ -1,34 +1,17 @@
 package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterLifePaths;
 
 import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharacters;
-import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Entity
-@AllArgsConstructor
-@NoArgsConstructor
 @Getter
 @Setter
-public class CpRedCharacterLifePaths {
-    @Id
-    @SequenceGenerator(
-            name = "cpRedCharacterLifePaths_sequence",
-            sequenceName = "cpRedCharacterLifePaths_sequence"
-    )
-    @GeneratedValue(
-            strategy = GenerationType.SEQUENCE,
-            generator = "cpRedCharacterLifePaths_sequence"
-    )
-    private Long id;
-    @ManyToOne
-    @JoinColumn(
-            name = "character_id",
-            referencedColumnName = "id"
-    )
-    private CpRedCharacters characterId;
+@NoArgsConstructor
+@AllArgsConstructor
+public class CpRedCharacterLifePathsRequest {
+    private Long characterId;
     private String cultureOfOrigin;
     private String yourCharacter;
     private String clothingAndStyle;

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterLifePaths/CpRedCharacterLifePathsService.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterLifePaths/CpRedCharacterLifePathsService.java
@@ -9,6 +9,8 @@ import dev.goral.rpghandyhelper.game.gameUsers.GameUsersRepository;
 import dev.goral.rpghandyhelper.game.gameUsers.GameUsersRole;
 import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharacters;
 import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharactersRepository;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterOtherInfo.CpRedCharacterOtherInfo;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterOtherInfo.CpRedCharacterOtherInfoRequest;
 import dev.goral.rpghandyhelper.security.CustomReturnables;
 import dev.goral.rpghandyhelper.security.exceptions.ResourceNotFoundException;
 import dev.goral.rpghandyhelper.user.User;
@@ -27,7 +29,7 @@ public class CpRedCharacterLifePathsService {
     private final dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterLifePaths.CpRedCharacterLifePathsRepository CpRedCharacterLifePathsRepository;
     private final UserRepository userRepository;
     private final CpRedCharactersRepository cpRedCharactersRepository;
-    private  final GameUsersRepository gameUsersRepository;
+    private final GameUsersRepository gameUsersRepository;
     private final CpRedCharacterLifePathsRepository cpRedCharacterLifePathsRepository;
 
 
@@ -57,7 +59,7 @@ public class CpRedCharacterLifePathsService {
         return response;
     }
 
-    public  Map<String, Object> getLifePathById(Long pathId) {
+    public Map<String, Object> getLifePathById(Long pathId) {
         CpRedCharacterLifePathsDTO path = CpRedCharacterLifePathsRepository.findById(pathId)
                 .map(cpRedCharacterLifePaths -> new CpRedCharacterLifePathsDTO(
                         cpRedCharacterLifePaths.getCharacterId().getId(),
@@ -112,23 +114,23 @@ public class CpRedCharacterLifePathsService {
         return response;
     }
 
-    public Map<String,Object> addLifePath(CpRedCharacterLifePathsRequest cpRedCharacterLifePaths) {
+    public Map<String, Object> addLifePath(CpRedCharacterLifePathsRequest cpRedCharacterLifePaths) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String currentUsername = authentication.getName();
         User currentUser = userRepository.findByUsername(currentUsername)
                 .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
-        if(
-                cpRedCharacterLifePaths.getYourCharacter()==null ||
-                cpRedCharacterLifePaths.getClothingAndStyle()==null ||
-                cpRedCharacterLifePaths.getHair()==null ||
-                cpRedCharacterLifePaths.getMostValue()==null ||
-                cpRedCharacterLifePaths.getRelationships()==null ||
-                cpRedCharacterLifePaths.getMostImportantPerson()==null ||
-                cpRedCharacterLifePaths.getMostImportantItem()==null ||
-                cpRedCharacterLifePaths.getFamilyBackground()==null ||
-                cpRedCharacterLifePaths.getFamilyEnvironment()==null ||
-                cpRedCharacterLifePaths.getFamilyCrisis()==null ||
-                cpRedCharacterLifePaths.getLifeGoals()==null
+        if (
+                cpRedCharacterLifePaths.getYourCharacter() == null ||
+                        cpRedCharacterLifePaths.getClothingAndStyle() == null ||
+                        cpRedCharacterLifePaths.getHair() == null ||
+                        cpRedCharacterLifePaths.getMostValue() == null ||
+                        cpRedCharacterLifePaths.getRelationships() == null ||
+                        cpRedCharacterLifePaths.getMostImportantPerson() == null ||
+                        cpRedCharacterLifePaths.getMostImportantItem() == null ||
+                        cpRedCharacterLifePaths.getFamilyBackground() == null ||
+                        cpRedCharacterLifePaths.getFamilyEnvironment() == null ||
+                        cpRedCharacterLifePaths.getFamilyCrisis() == null ||
+                        cpRedCharacterLifePaths.getLifeGoals() == null
         ) {
             throw new IllegalArgumentException("Wszystkie pola są wymagane.");
         }
@@ -136,12 +138,12 @@ public class CpRedCharacterLifePathsService {
         CpRedCharacters character = cpRedCharactersRepository.findById(cpRedCharacterLifePaths.getCharacterId())
                 .orElseThrow(() -> new ResourceNotFoundException("Postać o id " + cpRedCharacterLifePaths.getCharacterId() + " nie została znaleziona"));
 
-        Game game=character.getGame();
+        Game game = character.getGame();
         if (game == null) {
             throw new ResourceNotFoundException("Gra dla tej postaci nie została znaleziona.");
         }
 
-        if (game.getStatus()!= GameStatus.ACTIVE) {
+        if (game.getStatus() != GameStatus.ACTIVE) {
             throw new IllegalStateException("Gra nie jest aktywna.");
         }
 
@@ -150,103 +152,102 @@ public class CpRedCharacterLifePathsService {
             throw new ResourceNotFoundException("Nie znaleziono użytkownika w grze.");
         }
 
-        if(character.getUser()==null){
-            if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+        if (character.getUser() == null) {
+            if (gameUsers.getRole() != GameUsersRole.GAMEMASTER) {
                 throw new IllegalStateException("Nie masz uprawnień do dodawania ścieżki życiowej w dla tej postaci.");
             }
-        }
-        else if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+        } else if (gameUsers.getRole() != GameUsersRole.GAMEMASTER) {
             if (!character.getUser().getId().equals(currentUser.getId())) {
                 throw new IllegalStateException("Nie masz uprawnień do dodawania ścieżki życiowej dla tej postaci.");
             }
         }
 
-        if( CpRedCharacterLifePathsRepository.existsByCharacterId(character)) {
+        if (CpRedCharacterLifePathsRepository.existsByCharacterId(character)) {
             throw new IllegalArgumentException("Dodatkowe pathrmacje już istnieją dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getCultureOfOrigin().isEmpty()||
-                cpRedCharacterLifePaths.getCultureOfOrigin().trim().isEmpty()){
+        if (cpRedCharacterLifePaths.getCultureOfOrigin().isEmpty() ||
+                cpRedCharacterLifePaths.getCultureOfOrigin().trim().isEmpty()) {
             throw new IllegalArgumentException("Kultura pochodzenia nie może być puste dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getCultureOfOrigin().length()>500){
+        if (cpRedCharacterLifePaths.getCultureOfOrigin().length() > 500) {
             throw new IllegalArgumentException("Kultura pochodzenia nie może być dłuższa niż 500 znaków dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getYourCharacter().isEmpty()||
-                cpRedCharacterLifePaths.getYourCharacter().trim().isEmpty()){
+        if (cpRedCharacterLifePaths.getYourCharacter().isEmpty() ||
+                cpRedCharacterLifePaths.getYourCharacter().trim().isEmpty()) {
             throw new IllegalArgumentException("Twój charakter nie może być pusty dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getYourCharacter().length()>500) {
+        if (cpRedCharacterLifePaths.getYourCharacter().length() > 500) {
             throw new IllegalArgumentException("Twój charakter nie może być dłuższy niż 500 znaków dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getClothingAndStyle().isEmpty()||
-                cpRedCharacterLifePaths.getClothingAndStyle().trim().isEmpty()){
+        if (cpRedCharacterLifePaths.getClothingAndStyle().isEmpty() ||
+                cpRedCharacterLifePaths.getClothingAndStyle().trim().isEmpty()) {
             throw new IllegalArgumentException("Styl ubioru nie może być pusty dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getClothingAndStyle().length()>500) {
+        if (cpRedCharacterLifePaths.getClothingAndStyle().length() > 500) {
             throw new IllegalArgumentException("Styl ubioru nie może być dłuższy niż 500 znaków dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getHair().isEmpty()||
-                cpRedCharacterLifePaths.getHair().trim().isEmpty()){
+        if (cpRedCharacterLifePaths.getHair().isEmpty() ||
+                cpRedCharacterLifePaths.getHair().trim().isEmpty()) {
             throw new IllegalArgumentException("Rodzaj fryzury nie może być pusty dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getHair().length()>500) {
+        if (cpRedCharacterLifePaths.getHair().length() > 500) {
             throw new IllegalArgumentException("Rodzaj fryzury nie może być dłuższy niż 500 znaków dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getMostValue().isEmpty()||
-                cpRedCharacterLifePaths.getMostValue().trim().isEmpty()){
+        if (cpRedCharacterLifePaths.getMostValue().isEmpty() ||
+                cpRedCharacterLifePaths.getMostValue().trim().isEmpty()) {
             throw new IllegalArgumentException("Wartość życiowa nie może być pusta dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getMostValue().length()>500) {
+        if (cpRedCharacterLifePaths.getMostValue().length() > 500) {
             throw new IllegalArgumentException("Wartość życiowa nie może być dłuższa niż 500 znaków dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getRelationships().isEmpty()||
-                cpRedCharacterLifePaths.getRelationships().trim().isEmpty()){
+        if (cpRedCharacterLifePaths.getRelationships().isEmpty() ||
+                cpRedCharacterLifePaths.getRelationships().trim().isEmpty()) {
             throw new IllegalArgumentException("Relacje nie mogą być puste dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getRelationships().length()>500) {
+        if (cpRedCharacterLifePaths.getRelationships().length() > 500) {
             throw new IllegalArgumentException("Relacje nie mogą być dłuższe niż 500 znaków dla tej postaci.");
         }
 
-        if(cpRedCharacterLifePaths.getMostImportantPerson().isEmpty()||
-                cpRedCharacterLifePaths.getMostImportantPerson().trim().isEmpty()){
+        if (cpRedCharacterLifePaths.getMostImportantPerson().isEmpty() ||
+                cpRedCharacterLifePaths.getMostImportantPerson().trim().isEmpty()) {
             throw new IllegalArgumentException("Najważniejsza osoba nie może być pusta dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getMostImportantPerson().length()>255) {
+        if (cpRedCharacterLifePaths.getMostImportantPerson().length() > 255) {
             throw new IllegalArgumentException("Najważniejsza osoba nie może być dłuższa niż 255 znaków dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getMostImportantItem().isEmpty()||
-                cpRedCharacterLifePaths.getMostImportantItem().trim().isEmpty()){
+        if (cpRedCharacterLifePaths.getMostImportantItem().isEmpty() ||
+                cpRedCharacterLifePaths.getMostImportantItem().trim().isEmpty()) {
             throw new IllegalArgumentException("Najważniejszy przedmiot nie może być pusty dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getMostImportantItem().length()>255) {
+        if (cpRedCharacterLifePaths.getMostImportantItem().length() > 255) {
             throw new IllegalArgumentException("Najważniejszy przedmiot nie może być dłuższy niż 255 znaków dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getFamilyBackground().isEmpty()||
-                cpRedCharacterLifePaths.getFamilyBackground().trim().isEmpty()){
+        if (cpRedCharacterLifePaths.getFamilyBackground().isEmpty() ||
+                cpRedCharacterLifePaths.getFamilyBackground().trim().isEmpty()) {
             throw new IllegalArgumentException("Tło rodzinne nie może być puste dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getFamilyBackground().length()>500) {
+        if (cpRedCharacterLifePaths.getFamilyBackground().length() > 500) {
             throw new IllegalArgumentException("Środowisko rodzinne nie może być dłuższe niż 500 znaków dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getFamilyEnvironment().isEmpty()||
-                cpRedCharacterLifePaths.getFamilyEnvironment().trim().isEmpty()){
+        if (cpRedCharacterLifePaths.getFamilyEnvironment().isEmpty() ||
+                cpRedCharacterLifePaths.getFamilyEnvironment().trim().isEmpty()) {
             throw new IllegalArgumentException("Środowisko rodzinne nie może być puste dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getFamilyEnvironment().length()>500) {
+        if (cpRedCharacterLifePaths.getFamilyEnvironment().length() > 500) {
             throw new IllegalArgumentException("Środowisko rodzinne nie może być dłuższe niż 500 znaków dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getFamilyCrisis().isEmpty()||
-                cpRedCharacterLifePaths.getFamilyCrisis().trim().isEmpty()){
+        if (cpRedCharacterLifePaths.getFamilyCrisis().isEmpty() ||
+                cpRedCharacterLifePaths.getFamilyCrisis().trim().isEmpty()) {
             throw new IllegalArgumentException("Kryzys rodzinny nie może być pusty dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getFamilyCrisis().length()>500) {
+        if (cpRedCharacterLifePaths.getFamilyCrisis().length() > 500) {
             throw new IllegalArgumentException("Kryzys rodzinne nie może być dłuższy niż 500 znaków dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getLifeGoals().isEmpty()||
-                cpRedCharacterLifePaths.getLifeGoals().trim().isEmpty()){
+        if (cpRedCharacterLifePaths.getLifeGoals().isEmpty() ||
+                cpRedCharacterLifePaths.getLifeGoals().trim().isEmpty()) {
             throw new IllegalArgumentException("Cele życiowe nie mogą być puste dla tej postaci.");
         }
-        if(cpRedCharacterLifePaths.getLifeGoals().length()>500) {
+        if (cpRedCharacterLifePaths.getLifeGoals().length() > 500) {
             throw new IllegalArgumentException("Cele życiowe nie mogą być dłuższe niż 500 znaków dla tej postaci.");
         }
 
@@ -270,7 +271,8 @@ public class CpRedCharacterLifePathsService {
         cpRedCharacterLifePathsRepository.save(newpath);
         return CustomReturnables.getOkResponseMap("Ścieżka życiowa została dodana.");
     }
-    public Map<String, Object> deleteLifePaths(Long pathId) {
+
+    public Map<String, Object> deleteLifePath(Long pathId) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String currentUsername = authentication.getName();
         User currentUser = userRepository.findByUsername(currentUsername)
@@ -282,12 +284,12 @@ public class CpRedCharacterLifePathsService {
         CpRedCharacters character = cpRedCharactersRepository.findById(path.getCharacterId().getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Postać o id " + path.getCharacterId().getId() + " nie została znaleziona"));
 
-        Game game=character.getGame();
+        Game game = character.getGame();
         if (game == null) {
             throw new ResourceNotFoundException("Gra dla tej postaci nie została znaleziona.");
         }
 
-        if (game.getStatus()!= GameStatus.ACTIVE) {
+        if (game.getStatus() != GameStatus.ACTIVE) {
             throw new IllegalStateException("Gra nie jest aktywna.");
         }
         GameUsers gameUsers = gameUsersRepository.findByUserId(currentUser.getId());
@@ -295,12 +297,11 @@ public class CpRedCharacterLifePathsService {
             throw new ResourceNotFoundException("Nie znaleziono użytkownika w grze.");
         }
 
-        if(character.getUser()==null){
-            if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+        if (character.getUser() == null) {
+            if (gameUsers.getRole() != GameUsersRole.GAMEMASTER) {
                 throw new IllegalStateException("Nie masz uprawnień do usuwania Ścieżki życiowej w dla tej postaci.");
             }
-        }
-        else if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+        } else if (gameUsers.getRole() != GameUsersRole.GAMEMASTER) {
             if (!character.getUser().getId().equals(currentUser.getId())) {
                 throw new IllegalStateException("Nie masz uprawnień do usuwania Ścieżki życiowej dla tej postaci.");
             }
@@ -309,7 +310,7 @@ public class CpRedCharacterLifePathsService {
         return CustomReturnables.getOkResponseMap("Ścieżka życiowa o id " + pathId + " została usunięta.");
     }
 
-    public Map<String, Object> updateLifePaths(Long pathId, CpRedCharacterLifePathsRequest cpRedCharacterLifePaths) {
+    public Map<String, Object> updateLifePath(Long pathId, CpRedCharacterLifePathsRequest cpRedCharacterLifePaths) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String currentUsername = authentication.getName();
         User currentUser = userRepository.findByUsername(currentUsername)
@@ -321,12 +322,12 @@ public class CpRedCharacterLifePathsService {
         CpRedCharacters character = cpRedCharactersRepository.findById(pathToUpdate.getCharacterId().getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Postać o id " + pathToUpdate.getCharacterId().getId() + " nie została znaleziona"));
 
-        Game game=character.getGame();
+        Game game = character.getGame();
         if (game == null) {
             throw new ResourceNotFoundException("Gra dla tej postaci nie została znaleziona.");
         }
 
-        if (game.getStatus()!= GameStatus.ACTIVE) {
+        if (game.getStatus() != GameStatus.ACTIVE) {
             throw new IllegalStateException("Gra nie jest aktywna.");
         }
 
@@ -335,12 +336,11 @@ public class CpRedCharacterLifePathsService {
             throw new ResourceNotFoundException("Nie znaleziono użytkownika w grze.");
         }
 
-        if(character.getUser()==null){
-            if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+        if (character.getUser() == null) {
+            if (gameUsers.getRole() != GameUsersRole.GAMEMASTER) {
                 throw new IllegalStateException("Nie masz uprawnień do aktualizowania ścieżki życiowej dla tej postaci.");
             }
-        }
-        else if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+        } else if (gameUsers.getRole() != GameUsersRole.GAMEMASTER) {
             if (!character.getUser().getId().equals(currentUser.getId())) {
                 throw new IllegalStateException("Nie masz uprawnień do aktualizowania ścieżki życiowej dla tej postaci.");
             }
@@ -369,110 +369,110 @@ public class CpRedCharacterLifePathsService {
             }
             pathToUpdate.setYourCharacter(cpRedCharacterLifePaths.getYourCharacter());
         }
-        if( cpRedCharacterLifePaths.getClothingAndStyle() != null) {
-            if(cpRedCharacterLifePaths.getClothingAndStyle().isEmpty()||
-                    cpRedCharacterLifePaths.getClothingAndStyle().trim().isEmpty()){
+        if (cpRedCharacterLifePaths.getClothingAndStyle() != null) {
+            if (cpRedCharacterLifePaths.getClothingAndStyle().isEmpty() ||
+                    cpRedCharacterLifePaths.getClothingAndStyle().trim().isEmpty()) {
                 throw new IllegalArgumentException("Styl ubioru nie może być pusty dla tej postaci.");
             }
-            if(cpRedCharacterLifePaths.getClothingAndStyle().length()>500) {
+            if (cpRedCharacterLifePaths.getClothingAndStyle().length() > 500) {
                 throw new IllegalArgumentException("Styl ubioru nie może być dłuższy niż 500 znaków dla tej postaci.");
             }
-            }
-            pathToUpdate.setClothingAndStyle(cpRedCharacterLifePaths.getClothingAndStyle());
+        }
+        pathToUpdate.setClothingAndStyle(cpRedCharacterLifePaths.getClothingAndStyle());
 
         if (cpRedCharacterLifePaths.getHair() != null) {
-            if(cpRedCharacterLifePaths.getHair().isEmpty()||
-                cpRedCharacterLifePaths.getHair().trim().isEmpty()){
+            if (cpRedCharacterLifePaths.getHair().isEmpty() ||
+                    cpRedCharacterLifePaths.getHair().trim().isEmpty()) {
                 throw new IllegalArgumentException("Rodzaj fryzury nie może być pusty dla tej postaci.");
             }
-            if(cpRedCharacterLifePaths.getHair().length()>500) {
+            if (cpRedCharacterLifePaths.getHair().length() > 500) {
                 throw new IllegalArgumentException("Rodzaj fryzury nie może być dłuższy niż 500 znaków dla tej postaci.");
             }
         }
         pathToUpdate.setHair(cpRedCharacterLifePaths.getHair());
         if (cpRedCharacterLifePaths.getMostValue() != null) {
-            if(cpRedCharacterLifePaths.getMostValue().isEmpty()||
-                    cpRedCharacterLifePaths.getMostValue().trim().isEmpty()){
+            if (cpRedCharacterLifePaths.getMostValue().isEmpty() ||
+                    cpRedCharacterLifePaths.getMostValue().trim().isEmpty()) {
                 throw new IllegalArgumentException("Wartość życiowa nie może być pusta dla tej postaci.");
             }
-            if(cpRedCharacterLifePaths.getMostValue().length()>500) {
+            if (cpRedCharacterLifePaths.getMostValue().length() > 500) {
                 throw new IllegalArgumentException("Wartość życiowa nie może być dłuższa niż 500 znaków dla tej postaci.");
             }
         }
         pathToUpdate.setMostValue(cpRedCharacterLifePaths.getMostValue());
 
         if (cpRedCharacterLifePaths.getRelationships() != null) {
-            if(cpRedCharacterLifePaths.getRelationships().isEmpty()||
-                    cpRedCharacterLifePaths.getRelationships().trim().isEmpty()){
+            if (cpRedCharacterLifePaths.getRelationships().isEmpty() ||
+                    cpRedCharacterLifePaths.getRelationships().trim().isEmpty()) {
                 throw new IllegalArgumentException("Relacje nie mogą być puste dla tej postaci.");
             }
-            if(cpRedCharacterLifePaths.getRelationships().length()>500) {
+            if (cpRedCharacterLifePaths.getRelationships().length() > 500) {
                 throw new IllegalArgumentException("Relacje nie mogą być dłuższe niż 500 znaków dla tej postaci.");
             }
         }
         pathToUpdate.setRelationships(cpRedCharacterLifePaths.getRelationships());
 
         if (cpRedCharacterLifePaths.getMostImportantPerson() != null) {
-            if(cpRedCharacterLifePaths.getMostImportantPerson().isEmpty()||
-                    cpRedCharacterLifePaths.getMostImportantPerson().trim().isEmpty()){
+            if (cpRedCharacterLifePaths.getMostImportantPerson().isEmpty() ||
+                    cpRedCharacterLifePaths.getMostImportantPerson().trim().isEmpty()) {
                 throw new IllegalArgumentException("Najważniejsza osoba nie może być pusta dla tej postaci.");
             }
-            if(cpRedCharacterLifePaths.getMostImportantPerson().length()>255) {
+            if (cpRedCharacterLifePaths.getMostImportantPerson().length() > 255) {
                 throw new IllegalArgumentException("Najważniejsza osoba nie może być dłuższa niż 255 znaków dla tej postaci.");
             }
         }
         pathToUpdate.setMostImportantPerson(cpRedCharacterLifePaths.getMostImportantPerson());
 
         if (cpRedCharacterLifePaths.getMostImportantItem() != null) {
-            if(cpRedCharacterLifePaths.getMostImportantItem().isEmpty()||
-                    cpRedCharacterLifePaths.getMostImportantItem().trim().isEmpty()){
+            if (cpRedCharacterLifePaths.getMostImportantItem().isEmpty() ||
+                    cpRedCharacterLifePaths.getMostImportantItem().trim().isEmpty()) {
                 throw new IllegalArgumentException("Najważniejszy przedmiot nie może być pusty dla tej postaci.");
             }
-            if(cpRedCharacterLifePaths.getMostImportantItem().length()>255) {
+            if (cpRedCharacterLifePaths.getMostImportantItem().length() > 255) {
                 throw new IllegalArgumentException("Najważniejszy przedmiot nie może być dłuższy niż 255 znaków dla tej postaci.");
             }
         }
         pathToUpdate.setMostImportantItem(cpRedCharacterLifePaths.getMostImportantItem());
 
         if (cpRedCharacterLifePaths.getFamilyBackground() != null) {
-            if(cpRedCharacterLifePaths.getFamilyBackground().isEmpty()||
-                    cpRedCharacterLifePaths.getFamilyBackground().trim().isEmpty()){
+            if (cpRedCharacterLifePaths.getFamilyBackground().isEmpty() ||
+                    cpRedCharacterLifePaths.getFamilyBackground().trim().isEmpty()) {
                 throw new IllegalArgumentException("Tło rodzinne nie może być puste dla tej postaci.");
             }
-            if(cpRedCharacterLifePaths.getFamilyBackground().length()>500) {
+            if (cpRedCharacterLifePaths.getFamilyBackground().length() > 500) {
                 throw new IllegalArgumentException("Tło rodzinne nie może być dłuższe niż 500 znaków dla tej postaci.");
             }
         }
         pathToUpdate.setFamilyBackground(cpRedCharacterLifePaths.getFamilyBackground());
 
         if (cpRedCharacterLifePaths.getFamilyEnvironment() != null) {
-            if(cpRedCharacterLifePaths.getFamilyEnvironment().isEmpty()||
-                    cpRedCharacterLifePaths.getFamilyEnvironment().trim().isEmpty()){
+            if (cpRedCharacterLifePaths.getFamilyEnvironment().isEmpty() ||
+                    cpRedCharacterLifePaths.getFamilyEnvironment().trim().isEmpty()) {
                 throw new IllegalArgumentException("Środowisko rodzinne nie może być puste dla tej postaci.");
             }
-            if(cpRedCharacterLifePaths.getFamilyEnvironment().length()>500) {
+            if (cpRedCharacterLifePaths.getFamilyEnvironment().length() > 500) {
                 throw new IllegalArgumentException("Środowisko rodzinne nie może być dłuższe niż 500 znaków dla tej postaci.");
             }
         }
         pathToUpdate.setFamilyEnvironment(cpRedCharacterLifePaths.getFamilyEnvironment());
 
         if (cpRedCharacterLifePaths.getFamilyCrisis() != null) {
-            if(cpRedCharacterLifePaths.getFamilyCrisis().isEmpty()||
-                    cpRedCharacterLifePaths.getFamilyCrisis().trim().isEmpty()){
+            if (cpRedCharacterLifePaths.getFamilyCrisis().isEmpty() ||
+                    cpRedCharacterLifePaths.getFamilyCrisis().trim().isEmpty()) {
                 throw new IllegalArgumentException("Kryzys rodzinny nie może być pusty dla tej postaci.");
             }
-            if(cpRedCharacterLifePaths.getFamilyCrisis().length()>500) {
+            if (cpRedCharacterLifePaths.getFamilyCrisis().length() > 500) {
                 throw new IllegalArgumentException("Kryzys rodzinne nie może być dłuższy niż 500 znaków dla tej postaci.");
             }
         }
         pathToUpdate.setFamilyCrisis(cpRedCharacterLifePaths.getFamilyCrisis());
 
         if (cpRedCharacterLifePaths.getLifeGoals() != null) {
-            if(cpRedCharacterLifePaths.getLifeGoals().isEmpty()||
-                    cpRedCharacterLifePaths.getLifeGoals().trim().isEmpty()){
+            if (cpRedCharacterLifePaths.getLifeGoals().isEmpty() ||
+                    cpRedCharacterLifePaths.getLifeGoals().trim().isEmpty()) {
                 throw new IllegalArgumentException("Cele życiowe nie mogą być puste dla tej postaci.");
             }
-            if(cpRedCharacterLifePaths.getLifeGoals().length()>500) {
+            if (cpRedCharacterLifePaths.getLifeGoals().length() > 500) {
                 throw new IllegalArgumentException("Cele życiowe nie mogą być dłuższe niż 500 znaków dla tej postaci.");
             }
         }
@@ -482,3 +482,6 @@ public class CpRedCharacterLifePathsService {
         return CustomReturnables.getOkResponseMap("Ścieżka życiowa została zaktualizowana.");
     }
 }
+
+
+

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterLifePaths/CpRedCharacterLifePathsService.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterLifePaths/CpRedCharacterLifePathsService.java
@@ -1,0 +1,484 @@
+package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterLifePaths;
+
+
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterLifePaths.*;
+import dev.goral.rpghandyhelper.game.Game;
+import dev.goral.rpghandyhelper.game.GameStatus;
+import dev.goral.rpghandyhelper.game.gameUsers.GameUsers;
+import dev.goral.rpghandyhelper.game.gameUsers.GameUsersRepository;
+import dev.goral.rpghandyhelper.game.gameUsers.GameUsersRole;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharacters;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharactersRepository;
+import dev.goral.rpghandyhelper.security.CustomReturnables;
+import dev.goral.rpghandyhelper.security.exceptions.ResourceNotFoundException;
+import dev.goral.rpghandyhelper.user.User;
+import dev.goral.rpghandyhelper.user.UserRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@AllArgsConstructor
+public class CpRedCharacterLifePathsService {
+    private final dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterLifePaths.CpRedCharacterLifePathsRepository CpRedCharacterLifePathsRepository;
+    private final UserRepository userRepository;
+    private final CpRedCharactersRepository cpRedCharactersRepository;
+    private  final GameUsersRepository gameUsersRepository;
+    private final CpRedCharacterLifePathsRepository cpRedCharacterLifePathsRepository;
+
+
+    public Map<String, Object> getAllLifePaths() {
+        List<CpRedCharacterLifePaths> LifePaths = CpRedCharacterLifePathsRepository.findAll();
+        List<CpRedCharacterLifePathsDTO> LifePathsDTO = LifePaths.stream().map(path ->
+                new CpRedCharacterLifePathsDTO(
+                        path.getCharacterId().getId(),
+                        path.getCultureOfOrigin(),
+                        path.getYourCharacter(),
+                        path.getClothingAndStyle(),
+                        path.getHair(),
+                        path.getMostValue(),
+                        path.getRelationships(),
+                        path.getMostImportantPerson(),
+                        path.getMostImportantItem(),
+                        path.getFamilyBackground(),
+                        path.getFamilyEnvironment(),
+                        path.getFamilyCrisis(),
+                        path.getLifeGoals()
+                )).toList();
+        if (LifePathsDTO.isEmpty()) {
+            return CustomReturnables.getOkResponseMap("Brak ścieżki życiowej dla tej postaci.");
+        }
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano wszystkie ścieżki życiowe dla tej postaci.");
+        response.put("LifePaths", LifePathsDTO);
+        return response;
+    }
+
+    public  Map<String, Object> getLifePathById(Long pathId) {
+        CpRedCharacterLifePathsDTO path = CpRedCharacterLifePathsRepository.findById(pathId)
+                .map(cpRedCharacterLifePaths -> new CpRedCharacterLifePathsDTO(
+                        cpRedCharacterLifePaths.getCharacterId().getId(),
+                        cpRedCharacterLifePaths.getCultureOfOrigin(),
+                        cpRedCharacterLifePaths.getYourCharacter(),
+                        cpRedCharacterLifePaths.getClothingAndStyle(),
+                        cpRedCharacterLifePaths.getHair(),
+                        cpRedCharacterLifePaths.getMostValue(),
+                        cpRedCharacterLifePaths.getRelationships(),
+                        cpRedCharacterLifePaths.getMostImportantPerson(),
+                        cpRedCharacterLifePaths.getMostImportantItem(),
+                        cpRedCharacterLifePaths.getFamilyBackground(),
+                        cpRedCharacterLifePaths.getFamilyEnvironment(),
+                        cpRedCharacterLifePaths.getFamilyCrisis(),
+                        cpRedCharacterLifePaths.getLifeGoals()
+                )).orElseThrow(() -> new ResourceNotFoundException("Ścieżka życiowa o id " + pathId + " nie została znaleziona"));
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano ścieżkę życiową dla tej postaci.");
+        response.put("LifePath", path);
+        return response;
+    }
+
+    public Map<String, Object> getLifePathByCharacterId(Long characterId) {
+        List<CpRedCharacterLifePaths> LifePaths = CpRedCharacterLifePathsRepository.findAllByCharacterId_Id(characterId);
+        if (LifePaths.isEmpty()) {
+            return CustomReturnables.getOkResponseMap("Brak ścieżki życiowej dla postaci o id " + characterId);
+        }
+        List<CpRedCharacterLifePathsDTO> LifePathsDTO = LifePaths.stream().map(path ->
+                new CpRedCharacterLifePathsDTO(
+                        path.getCharacterId().getId(),
+                        path.getCultureOfOrigin(),
+                        path.getYourCharacter(),
+                        path.getClothingAndStyle(),
+                        path.getHair(),
+                        path.getMostValue(),
+                        path.getRelationships(),
+                        path.getMostImportantPerson(),
+                        path.getMostImportantItem(),
+                        path.getFamilyBackground(),
+                        path.getFamilyEnvironment(),
+                        path.getFamilyCrisis(),
+                        path.getLifeGoals()
+                )).toList();
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano ścieżkę życiową dla postaci o id " + characterId);
+        response.put("LifePath", LifePathsDTO);
+        return response;
+    }
+
+    public Map<String, Object> getAllLifePathsForAdmin() {
+        List<CpRedCharacterLifePaths> allLifePaths = CpRedCharacterLifePathsRepository.findAll();
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano wszystkie ścieżki życiowe.");
+        response.put("LifePaths", allLifePaths);
+        return response;
+    }
+
+    public Map<String,Object> addLifePath(CpRedCharacterLifePathsRequest cpRedCharacterLifePaths) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
+        if(
+                cpRedCharacterLifePaths.getYourCharacter()==null ||
+                cpRedCharacterLifePaths.getClothingAndStyle()==null ||
+                cpRedCharacterLifePaths.getHair()==null ||
+                cpRedCharacterLifePaths.getMostValue()==null ||
+                cpRedCharacterLifePaths.getRelationships()==null ||
+                cpRedCharacterLifePaths.getMostImportantPerson()==null ||
+                cpRedCharacterLifePaths.getMostImportantItem()==null ||
+                cpRedCharacterLifePaths.getFamilyBackground()==null ||
+                cpRedCharacterLifePaths.getFamilyEnvironment()==null ||
+                cpRedCharacterLifePaths.getFamilyCrisis()==null ||
+                cpRedCharacterLifePaths.getLifeGoals()==null
+        ) {
+            throw new IllegalArgumentException("Wszystkie pola są wymagane.");
+        }
+
+        CpRedCharacters character = cpRedCharactersRepository.findById(cpRedCharacterLifePaths.getCharacterId())
+                .orElseThrow(() -> new ResourceNotFoundException("Postać o id " + cpRedCharacterLifePaths.getCharacterId() + " nie została znaleziona"));
+
+        Game game=character.getGame();
+        if (game == null) {
+            throw new ResourceNotFoundException("Gra dla tej postaci nie została znaleziona.");
+        }
+
+        if (game.getStatus()!= GameStatus.ACTIVE) {
+            throw new IllegalStateException("Gra nie jest aktywna.");
+        }
+
+        GameUsers gameUsers = gameUsersRepository.findByGameIdAndUserId(character.getGame().getId(), currentUser.getId());
+        if (gameUsers == null) {
+            throw new ResourceNotFoundException("Nie znaleziono użytkownika w grze.");
+        }
+
+        if(character.getUser()==null){
+            if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+                throw new IllegalStateException("Nie masz uprawnień do dodawania ścieżki życiowej w dla tej postaci.");
+            }
+        }
+        else if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+            if (!character.getUser().getId().equals(currentUser.getId())) {
+                throw new IllegalStateException("Nie masz uprawnień do dodawania ścieżki życiowej dla tej postaci.");
+            }
+        }
+
+        if( CpRedCharacterLifePathsRepository.existsByCharacterId(character)) {
+            throw new IllegalArgumentException("Dodatkowe pathrmacje już istnieją dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getCultureOfOrigin().isEmpty()||
+                cpRedCharacterLifePaths.getCultureOfOrigin().trim().isEmpty()){
+            throw new IllegalArgumentException("Kultura pochodzenia nie może być puste dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getCultureOfOrigin().length()>500){
+            throw new IllegalArgumentException("Kultura pochodzenia nie może być dłuższa niż 500 znaków dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getYourCharacter().isEmpty()||
+                cpRedCharacterLifePaths.getYourCharacter().trim().isEmpty()){
+            throw new IllegalArgumentException("Twój charakter nie może być pusty dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getYourCharacter().length()>500) {
+            throw new IllegalArgumentException("Twój charakter nie może być dłuższy niż 500 znaków dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getClothingAndStyle().isEmpty()||
+                cpRedCharacterLifePaths.getClothingAndStyle().trim().isEmpty()){
+            throw new IllegalArgumentException("Styl ubioru nie może być pusty dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getClothingAndStyle().length()>500) {
+            throw new IllegalArgumentException("Styl ubioru nie może być dłuższy niż 500 znaków dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getHair().isEmpty()||
+                cpRedCharacterLifePaths.getHair().trim().isEmpty()){
+            throw new IllegalArgumentException("Rodzaj fryzury nie może być pusty dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getHair().length()>500) {
+            throw new IllegalArgumentException("Rodzaj fryzury nie może być dłuższy niż 500 znaków dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getMostValue().isEmpty()||
+                cpRedCharacterLifePaths.getMostValue().trim().isEmpty()){
+            throw new IllegalArgumentException("Wartość życiowa nie może być pusta dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getMostValue().length()>500) {
+            throw new IllegalArgumentException("Wartość życiowa nie może być dłuższa niż 500 znaków dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getRelationships().isEmpty()||
+                cpRedCharacterLifePaths.getRelationships().trim().isEmpty()){
+            throw new IllegalArgumentException("Relacje nie mogą być puste dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getRelationships().length()>500) {
+            throw new IllegalArgumentException("Relacje nie mogą być dłuższe niż 500 znaków dla tej postaci.");
+        }
+
+        if(cpRedCharacterLifePaths.getMostImportantPerson().isEmpty()||
+                cpRedCharacterLifePaths.getMostImportantPerson().trim().isEmpty()){
+            throw new IllegalArgumentException("Najważniejsza osoba nie może być pusta dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getMostImportantPerson().length()>255) {
+            throw new IllegalArgumentException("Najważniejsza osoba nie może być dłuższa niż 255 znaków dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getMostImportantItem().isEmpty()||
+                cpRedCharacterLifePaths.getMostImportantItem().trim().isEmpty()){
+            throw new IllegalArgumentException("Najważniejszy przedmiot nie może być pusty dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getMostImportantItem().length()>255) {
+            throw new IllegalArgumentException("Najważniejszy przedmiot nie może być dłuższy niż 255 znaków dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getFamilyBackground().isEmpty()||
+                cpRedCharacterLifePaths.getFamilyBackground().trim().isEmpty()){
+            throw new IllegalArgumentException("Tło rodzinne nie może być puste dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getFamilyBackground().length()>500) {
+            throw new IllegalArgumentException("Środowisko rodzinne nie może być dłuższe niż 500 znaków dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getFamilyEnvironment().isEmpty()||
+                cpRedCharacterLifePaths.getFamilyEnvironment().trim().isEmpty()){
+            throw new IllegalArgumentException("Środowisko rodzinne nie może być puste dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getFamilyEnvironment().length()>500) {
+            throw new IllegalArgumentException("Środowisko rodzinne nie może być dłuższe niż 500 znaków dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getFamilyCrisis().isEmpty()||
+                cpRedCharacterLifePaths.getFamilyCrisis().trim().isEmpty()){
+            throw new IllegalArgumentException("Kryzys rodzinny nie może być pusty dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getFamilyCrisis().length()>500) {
+            throw new IllegalArgumentException("Kryzys rodzinne nie może być dłuższy niż 500 znaków dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getLifeGoals().isEmpty()||
+                cpRedCharacterLifePaths.getLifeGoals().trim().isEmpty()){
+            throw new IllegalArgumentException("Cele życiowe nie mogą być puste dla tej postaci.");
+        }
+        if(cpRedCharacterLifePaths.getLifeGoals().length()>500) {
+            throw new IllegalArgumentException("Cele życiowe nie mogą być dłuższe niż 500 znaków dla tej postaci.");
+        }
+
+        CpRedCharacterLifePaths newpath = new CpRedCharacterLifePaths(
+                null,
+                character,
+                cpRedCharacterLifePaths.getCultureOfOrigin(),
+                cpRedCharacterLifePaths.getYourCharacter(),
+                cpRedCharacterLifePaths.getClothingAndStyle(),
+                cpRedCharacterLifePaths.getHair(),
+                cpRedCharacterLifePaths.getMostValue(),
+                cpRedCharacterLifePaths.getRelationships(),
+                cpRedCharacterLifePaths.getMostImportantPerson(),
+                cpRedCharacterLifePaths.getMostImportantItem(),
+                cpRedCharacterLifePaths.getFamilyBackground(),
+                cpRedCharacterLifePaths.getFamilyEnvironment(),
+                cpRedCharacterLifePaths.getFamilyCrisis(),
+                cpRedCharacterLifePaths.getLifeGoals()
+
+        );
+        cpRedCharacterLifePathsRepository.save(newpath);
+        return CustomReturnables.getOkResponseMap("Ścieżka życiowa została dodana.");
+    }
+    public Map<String, Object> deleteLifePaths(Long pathId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
+
+        CpRedCharacterLifePaths path = cpRedCharacterLifePathsRepository.findById(pathId)
+                .orElseThrow(() -> new ResourceNotFoundException("Ścieżka życiowa o id " + pathId + " nie została znaleziona"));
+
+        CpRedCharacters character = cpRedCharactersRepository.findById(path.getCharacterId().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Postać o id " + path.getCharacterId().getId() + " nie została znaleziona"));
+
+        Game game=character.getGame();
+        if (game == null) {
+            throw new ResourceNotFoundException("Gra dla tej postaci nie została znaleziona.");
+        }
+
+        if (game.getStatus()!= GameStatus.ACTIVE) {
+            throw new IllegalStateException("Gra nie jest aktywna.");
+        }
+        GameUsers gameUsers = gameUsersRepository.findByUserId(currentUser.getId());
+        if (gameUsers == null) {
+            throw new ResourceNotFoundException("Nie znaleziono użytkownika w grze.");
+        }
+
+        if(character.getUser()==null){
+            if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+                throw new IllegalStateException("Nie masz uprawnień do usuwania Ścieżki życiowej w dla tej postaci.");
+            }
+        }
+        else if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+            if (!character.getUser().getId().equals(currentUser.getId())) {
+                throw new IllegalStateException("Nie masz uprawnień do usuwania Ścieżki życiowej dla tej postaci.");
+            }
+        }
+        cpRedCharacterLifePathsRepository.deleteById(pathId);
+        return CustomReturnables.getOkResponseMap("Ścieżka życiowa o id " + pathId + " została usunięta.");
+    }
+
+    public Map<String, Object> updateLifePaths(Long pathId, CpRedCharacterLifePathsRequest cpRedCharacterLifePaths) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
+
+        CpRedCharacterLifePaths pathToUpdate = cpRedCharacterLifePathsRepository.findById(pathId)
+                .orElseThrow(() -> new ResourceNotFoundException("Ścieżka życiowa o id " + pathId + " nie została znaleziona"));
+
+        CpRedCharacters character = cpRedCharactersRepository.findById(pathToUpdate.getCharacterId().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Postać o id " + pathToUpdate.getCharacterId().getId() + " nie została znaleziona"));
+
+        Game game=character.getGame();
+        if (game == null) {
+            throw new ResourceNotFoundException("Gra dla tej postaci nie została znaleziona.");
+        }
+
+        if (game.getStatus()!= GameStatus.ACTIVE) {
+            throw new IllegalStateException("Gra nie jest aktywna.");
+        }
+
+        GameUsers gameUsers = gameUsersRepository.findByGameIdAndUserId(character.getGame().getId(), currentUser.getId());
+        if (gameUsers == null) {
+            throw new ResourceNotFoundException("Nie znaleziono użytkownika w grze.");
+        }
+
+        if(character.getUser()==null){
+            if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+                throw new IllegalStateException("Nie masz uprawnień do aktualizowania ścieżki życiowej dla tej postaci.");
+            }
+        }
+        else if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
+            if (!character.getUser().getId().equals(currentUser.getId())) {
+                throw new IllegalStateException("Nie masz uprawnień do aktualizowania ścieżki życiowej dla tej postaci.");
+            }
+        }
+
+        if (pathToUpdate.getCharacterId().getId() != cpRedCharacterLifePaths.getCharacterId()) {
+            throw new IllegalArgumentException("Nie można zmienić postaci przypisanej ścieżki życiowej.");
+        }
+        if (cpRedCharacterLifePaths.getCultureOfOrigin() != null) {
+            if (cpRedCharacterLifePaths.getCultureOfOrigin().isEmpty() ||
+                    cpRedCharacterLifePaths.getCultureOfOrigin().trim().isEmpty()) {
+                throw new IllegalArgumentException("Kultura pochodzenia nie może być pusta dla tej postaci.");
+            }
+            if (cpRedCharacterLifePaths.getCultureOfOrigin().length() > 500) {
+                throw new IllegalArgumentException("Kultura pochodzenia nie może być dłuższa niż 500 znaków dla tej postaci.");
+            }
+            pathToUpdate.setCultureOfOrigin(cpRedCharacterLifePaths.getCultureOfOrigin());
+        }
+        if (cpRedCharacterLifePaths.getYourCharacter() != null) {
+            if (cpRedCharacterLifePaths.getYourCharacter().isEmpty() ||
+                    cpRedCharacterLifePaths.getYourCharacter().trim().isEmpty()) {
+                throw new IllegalArgumentException("Twój charakter nie może być pusty dla tej postaci.");
+            }
+            if (cpRedCharacterLifePaths.getYourCharacter().length() > 500) {
+                throw new IllegalArgumentException("Twój charakter nie może być dłuższy niż 500 znaków dla tej postaci.");
+            }
+            pathToUpdate.setYourCharacter(cpRedCharacterLifePaths.getYourCharacter());
+        }
+        if( cpRedCharacterLifePaths.getClothingAndStyle() != null) {
+            if(cpRedCharacterLifePaths.getClothingAndStyle().isEmpty()||
+                    cpRedCharacterLifePaths.getClothingAndStyle().trim().isEmpty()){
+                throw new IllegalArgumentException("Styl ubioru nie może być pusty dla tej postaci.");
+            }
+            if(cpRedCharacterLifePaths.getClothingAndStyle().length()>500) {
+                throw new IllegalArgumentException("Styl ubioru nie może być dłuższy niż 500 znaków dla tej postaci.");
+            }
+            }
+            pathToUpdate.setClothingAndStyle(cpRedCharacterLifePaths.getClothingAndStyle());
+
+        if (cpRedCharacterLifePaths.getHair() != null) {
+            if(cpRedCharacterLifePaths.getHair().isEmpty()||
+                cpRedCharacterLifePaths.getHair().trim().isEmpty()){
+                throw new IllegalArgumentException("Rodzaj fryzury nie może być pusty dla tej postaci.");
+            }
+            if(cpRedCharacterLifePaths.getHair().length()>500) {
+                throw new IllegalArgumentException("Rodzaj fryzury nie może być dłuższy niż 500 znaków dla tej postaci.");
+            }
+        }
+        pathToUpdate.setHair(cpRedCharacterLifePaths.getHair());
+        if (cpRedCharacterLifePaths.getMostValue() != null) {
+            if(cpRedCharacterLifePaths.getMostValue().isEmpty()||
+                    cpRedCharacterLifePaths.getMostValue().trim().isEmpty()){
+                throw new IllegalArgumentException("Wartość życiowa nie może być pusta dla tej postaci.");
+            }
+            if(cpRedCharacterLifePaths.getMostValue().length()>500) {
+                throw new IllegalArgumentException("Wartość życiowa nie może być dłuższa niż 500 znaków dla tej postaci.");
+            }
+        }
+        pathToUpdate.setMostValue(cpRedCharacterLifePaths.getMostValue());
+
+        if (cpRedCharacterLifePaths.getRelationships() != null) {
+            if(cpRedCharacterLifePaths.getRelationships().isEmpty()||
+                    cpRedCharacterLifePaths.getRelationships().trim().isEmpty()){
+                throw new IllegalArgumentException("Relacje nie mogą być puste dla tej postaci.");
+            }
+            if(cpRedCharacterLifePaths.getRelationships().length()>500) {
+                throw new IllegalArgumentException("Relacje nie mogą być dłuższe niż 500 znaków dla tej postaci.");
+            }
+        }
+        pathToUpdate.setRelationships(cpRedCharacterLifePaths.getRelationships());
+
+        if (cpRedCharacterLifePaths.getMostImportantPerson() != null) {
+            if(cpRedCharacterLifePaths.getMostImportantPerson().isEmpty()||
+                    cpRedCharacterLifePaths.getMostImportantPerson().trim().isEmpty()){
+                throw new IllegalArgumentException("Najważniejsza osoba nie może być pusta dla tej postaci.");
+            }
+            if(cpRedCharacterLifePaths.getMostImportantPerson().length()>255) {
+                throw new IllegalArgumentException("Najważniejsza osoba nie może być dłuższa niż 255 znaków dla tej postaci.");
+            }
+        }
+        pathToUpdate.setMostImportantPerson(cpRedCharacterLifePaths.getMostImportantPerson());
+
+        if (cpRedCharacterLifePaths.getMostImportantItem() != null) {
+            if(cpRedCharacterLifePaths.getMostImportantItem().isEmpty()||
+                    cpRedCharacterLifePaths.getMostImportantItem().trim().isEmpty()){
+                throw new IllegalArgumentException("Najważniejszy przedmiot nie może być pusty dla tej postaci.");
+            }
+            if(cpRedCharacterLifePaths.getMostImportantItem().length()>255) {
+                throw new IllegalArgumentException("Najważniejszy przedmiot nie może być dłuższy niż 255 znaków dla tej postaci.");
+            }
+        }
+        pathToUpdate.setMostImportantItem(cpRedCharacterLifePaths.getMostImportantItem());
+
+        if (cpRedCharacterLifePaths.getFamilyBackground() != null) {
+            if(cpRedCharacterLifePaths.getFamilyBackground().isEmpty()||
+                    cpRedCharacterLifePaths.getFamilyBackground().trim().isEmpty()){
+                throw new IllegalArgumentException("Tło rodzinne nie może być puste dla tej postaci.");
+            }
+            if(cpRedCharacterLifePaths.getFamilyBackground().length()>500) {
+                throw new IllegalArgumentException("Tło rodzinne nie może być dłuższe niż 500 znaków dla tej postaci.");
+            }
+        }
+        pathToUpdate.setFamilyBackground(cpRedCharacterLifePaths.getFamilyBackground());
+
+        if (cpRedCharacterLifePaths.getFamilyEnvironment() != null) {
+            if(cpRedCharacterLifePaths.getFamilyEnvironment().isEmpty()||
+                    cpRedCharacterLifePaths.getFamilyEnvironment().trim().isEmpty()){
+                throw new IllegalArgumentException("Środowisko rodzinne nie może być puste dla tej postaci.");
+            }
+            if(cpRedCharacterLifePaths.getFamilyEnvironment().length()>500) {
+                throw new IllegalArgumentException("Środowisko rodzinne nie może być dłuższe niż 500 znaków dla tej postaci.");
+            }
+        }
+        pathToUpdate.setFamilyEnvironment(cpRedCharacterLifePaths.getFamilyEnvironment());
+
+        if (cpRedCharacterLifePaths.getFamilyCrisis() != null) {
+            if(cpRedCharacterLifePaths.getFamilyCrisis().isEmpty()||
+                    cpRedCharacterLifePaths.getFamilyCrisis().trim().isEmpty()){
+                throw new IllegalArgumentException("Kryzys rodzinny nie może być pusty dla tej postaci.");
+            }
+            if(cpRedCharacterLifePaths.getFamilyCrisis().length()>500) {
+                throw new IllegalArgumentException("Kryzys rodzinne nie może być dłuższy niż 500 znaków dla tej postaci.");
+            }
+        }
+        pathToUpdate.setFamilyCrisis(cpRedCharacterLifePaths.getFamilyCrisis());
+
+        if (cpRedCharacterLifePaths.getLifeGoals() != null) {
+            if(cpRedCharacterLifePaths.getLifeGoals().isEmpty()||
+                    cpRedCharacterLifePaths.getLifeGoals().trim().isEmpty()){
+                throw new IllegalArgumentException("Cele życiowe nie mogą być puste dla tej postaci.");
+            }
+            if(cpRedCharacterLifePaths.getLifeGoals().length()>500) {
+                throw new IllegalArgumentException("Cele życiowe nie mogą być dłuższe niż 500 znaków dla tej postaci.");
+            }
+        }
+        pathToUpdate.setLifeGoals(cpRedCharacterLifePaths.getLifeGoals());
+
+        cpRedCharacterLifePathsRepository.save(pathToUpdate);
+        return CustomReturnables.getOkResponseMap("Ścieżka życiowa została zaktualizowana.");
+    }
+}

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterLifePaths/CpRedCharacterLifePathsService.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterLifePaths/CpRedCharacterLifePathsService.java
@@ -163,7 +163,7 @@ public class CpRedCharacterLifePathsService {
         }
 
         if (CpRedCharacterLifePathsRepository.existsByCharacterId(character)) {
-            throw new IllegalArgumentException("Dodatkowe pathrmacje już istnieją dla tej postaci.");
+            throw new IllegalArgumentException("Ścieżka życiowa już istnieje dla tej postaci.");
         }
         if (cpRedCharacterLifePaths.getCultureOfOrigin().isEmpty() ||
                 cpRedCharacterLifePaths.getCultureOfOrigin().trim().isEmpty()) {

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoController.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoController.java
@@ -12,37 +12,37 @@ public class CpRedCharacterOtherInfoController {
     private final CpRedCharacterOtherInfoService cpRedCharacterOtherInfoService;
 
 
-    @GetMapping(path = "/rpgSystems/cpRed/character/OtherInfo/all")
+    @GetMapping(path = "/rpgSystems/cpRed/character/otherinfo/all")
     public Map<String, Object> getAllOtherInfo() {
         return cpRedCharacterOtherInfoService.getAllOtherInfo();
     }
 
-    @GetMapping(path = "/rpgSystems/cpRed/character/OtherInfo/{infoId}")
+    @GetMapping(path = "/rpgSystems/cpRed/character/otherinfo/{infoId}")
     public Map<String, Object> getOtherInfoById(@PathVariable("infoId") Long infoId) {
         return cpRedCharacterOtherInfoService.getOtherInfoById(infoId);
     }
 
-    @GetMapping(path = "/rpgSystems/cpRed/character/OtherInfo/character/{characterId}")
+    @GetMapping(path = "/rpgSystems/cpRed/character/otherinfo/character/{characterId}")
     public Map<String, Object> getOtherInfoByCharacterId(@PathVariable("characterId") Long characterId) {
         return cpRedCharacterOtherInfoService.getOtherInfoByCharacterId(characterId);
     }
 
-    @GetMapping(path = "/admin/rpgSystems/cpRed/character/OtherInfo/all")
+    @GetMapping(path = "/admin/rpgSystems/cpRed/character/otherinfo/all")
     public Map<String, Object> getAllOtherInfoForAdmin() {
         return cpRedCharacterOtherInfoService.getAllOtherInfoForAdmin();
     }
 
-    @PostMapping(path = "/rpgSystems/cpRed/character/OtherInfo/add")
+    @PostMapping(path = "/rpgSystems/cpRed/character/otherinfo/add")
     public Map<String, Object> addOtherInfo(@RequestBody CpRedCharacterOtherInfoRequest cpRedCharacterOtherInfo) {
         return cpRedCharacterOtherInfoService.addOtherInfo(cpRedCharacterOtherInfo);
     }
 
-    @DeleteMapping(path = "/rpgSystems/cpRed/character/OtherInfo/delete/{infoId}")
+    @DeleteMapping(path = "/rpgSystems/cpRed/character/otherinfo/delete/{infoId}")
     public Map<String, Object> deleteOtherInfo(@PathVariable("infoId") Long infoId) {
         return cpRedCharacterOtherInfoService.deleteOtherInfo(infoId);
     }
 
-    @PutMapping(path = "/rpgSystems/cpRed/character/OtherInfo/update/{infoId}")
+    @PutMapping(path = "/rpgSystems/cpRed/character/otherinfo/update/{infoId}")
     public Map<String, Object> updateOtherInfo(@PathVariable("infoId") Long infoId,
                                                @RequestBody CpRedCharacterOtherInfoRequest cpRedCharacterOtherInfo) {
         return cpRedCharacterOtherInfoService.updateOtherInfo(infoId, cpRedCharacterOtherInfo);

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoService.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterOtherInfo/CpRedCharacterOtherInfoService.java
@@ -242,12 +242,12 @@ public class CpRedCharacterOtherInfoService {
 
         if(character.getUser()==null){
             if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
-                throw new IllegalStateException("Nie masz uprawnień do dodawania dodatkowych informacji w dla tej postaci.");
+                throw new IllegalStateException("Nie masz uprawnień do usuwania dodatkowych informacji w dla tej postaci.");
             }
         }
         else if (gameUsers.getRole()!= GameUsersRole.GAMEMASTER){
             if (!character.getUser().getId().equals(currentUser.getId())) {
-                throw new IllegalStateException("Nie masz uprawnień do dodawania dodatkowych informacji dla tej postaci.");
+                throw new IllegalStateException("Nie masz uprawnień do usuwania dodatkowych informacji dla tej postaci.");
             }
         }
         cpRedCharacterOtherInfoRepository.deleteById(infoId);


### PR DESCRIPTION
Dodałem wszystkie endpointy do ścieżki życiowej dla karty postaci

Funkcjonalności:

-     możliwość tworzenia nowych ścieżek (GM lub właściciel karty)
-     edycja aktualnych ścieżek (GM lub właściciel karty)
-     przegląd wszystkich zapisanych ścieżek (wszyscy)
-     możliwość wyszukania ścieżek po ID (wszyscy)
-     przegląd wszystkich zapisanych ścieżek po ID karty postaci (wszyscy)
-     funkcja zwrotu wszystkich ścieżek formie obiektów klasy (Admin)
-     funkcja usunięcia ścieżki (GM lub właściciel karty)

Testowanie:

-     Zaloguj się jako User 1 (właściciel karty)
-     Stwórz ścieżkę
-     Wyświetl wszystkie ścieżki
-     Wyświetl ścieżkę po ID
-     Zmodyfikuj ścieżkę
-     Wyloguj się
-     Zaloguj się jako Admin
-     Wyświetl ścieżkę w formie obiektu
-     Zaloguj się jako User 1 (GM)
-     Usuń ścieżkę
-     Wyświetl ścieżkę po ID karty postaci

Wszystkie endpointy są w jetcliencie. Cała klasa opiera się o erd. Każdy character może mieć tylko jeden obiekt tego typu.