### PR TITLE
CpRedCharacterCustomEquipment

### DIFF
--- a/.idea/JetClient/state.xml
+++ b/.idea/JetClient/state.xml
@@ -2466,6 +2466,57 @@
                                       <folderState>
                                         <option name="id" value="6df132bd-1344-4455-8adf-094ded1bbc36" />
                                         <option name="name" value="Custom" />
+                                        <option name="requests">
+                                          <list>
+                                            <requestState>
+                                              <option name="body">
+                                                <bodyState>
+                                                  <option name="raw" value="{&#10;  customItemId: 1,&#10;  characterId: 1,&#10;  quantity: 3,&#10;  status: &quot;EQUIPPED&quot; // &quot;EQUIPPED&quot; / &quot;STORED&quot;&#10;}" />
+                                                  <option name="type" value="JSON" />
+                                                </bodyState>
+                                              </option>
+                                              <option name="id" value="4fb6d6c9-7924-41cf-8ebf-92514da06511" />
+                                              <option name="method" value="POST" />
+                                              <option name="name" value="Dodaj customowe wyposażenie do postaci" />
+                                              <option name="sortWeight" value="1000000" />
+                                              <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/customEquipments/create" />
+                                            </requestState>
+                                            <requestState>
+                                              <option name="id" value="f77ccb74-3c4d-45e2-9fdf-e3abe8e5a0c5" />
+                                              <option name="method" value="GET" />
+                                              <option name="name" value="Pobierz customowe wyposarzenie postaci o podanym ID" />
+                                              <option name="sortWeight" value="2000000" />
+                                              <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/customEquipments/1" />
+                                            </requestState>
+                                            <requestState>
+                                              <option name="id" value="80408398-f4b5-4367-b94f-bc8838c7ab4b" />
+                                              <option name="method" value="GET" />
+                                              <option name="name" value="Pobierz wszystkie customowe wyposażenia wszystkich postaci" />
+                                              <option name="sortWeight" value="3000000" />
+                                              <option name="url" value="http://localhost:8888/api/v1/authorized/admin/games/cpRed/characters/customEquipments/all" />
+                                            </requestState>
+                                            <requestState>
+                                              <option name="body">
+                                                <bodyState>
+                                                  <option name="raw" value="{&#10;  quantity: 10,&#10;  status: &quot;STORED&quot;, // &quot;EQUIPPED&quot; / &quot;STORED&quot;&#10;  description: &quot;Piękny zmodyikowny opis...zachwycać się, to jest rozkaz&quot;&#10;}" />
+                                                  <option name="type" value="JSON" />
+                                                </bodyState>
+                                              </option>
+                                              <option name="id" value="583e8d46-3ca2-49b5-a8be-205031f935e4" />
+                                              <option name="method" value="PUT" />
+                                              <option name="name" value="Modyfikuj customowe wyposażenie postaci" />
+                                              <option name="sortWeight" value="4000000" />
+                                              <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/customEquipments/update/1" />
+                                            </requestState>
+                                            <requestState>
+                                              <option name="id" value="4ef28b27-dc76-4081-9aa8-1e07292b43da" />
+                                              <option name="method" value="DELETE" />
+                                              <option name="name" value="Usuń customowe wyposażenie postaci" />
+                                              <option name="sortWeight" value="5000000" />
+                                              <option name="url" value="http://localhost:8888/api/v1/authorized/games/cpRed/characters/customEquipments/delete/1" />
+                                            </requestState>
+                                          </list>
+                                        </option>
                                         <option name="sortWeight" value="2000000" />
                                       </folderState>
                                     </list>

--- a/src/main/java/dev/goral/rpghandyhelper/game/GameService.java
+++ b/src/main/java/dev/goral/rpghandyhelper/game/GameService.java
@@ -5,6 +5,7 @@ import dev.goral.rpghandyhelper.game.gameUsers.*;
 import dev.goral.rpghandyhelper.rpgSystems.RpgSystemsRepository;
 import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharacters;
 import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharactersRepository;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharactersType;
 import dev.goral.rpghandyhelper.security.CustomReturnables;
 import dev.goral.rpghandyhelper.security.exceptions.ForbiddenActionException;
 import dev.goral.rpghandyhelper.security.exceptions.ResourceNotFoundException;
@@ -262,6 +263,7 @@ public class GameService {
 
         if(character!=null) {
             character.setUser(null);
+            character.setType(CpRedCharactersType.NPC);
         }
         gameUsersRepository.delete(delUser);
         return CustomReturnables.getOkResponseMap("Użytkownik został usunięty z gry.");

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomEquipment/AddCharacterCustomEquipmentRequest.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomEquipment/AddCharacterCustomEquipmentRequest.java
@@ -1,0 +1,18 @@
+package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterCustomEquipment;
+
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterItem.CpRedCharacterItemStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AddCharacterCustomEquipmentRequest {
+    private Long customItemId;
+    private Long characterId;
+    private Integer quantity;
+    private CpRedCharacterItemStatus status;
+}

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomEquipment/CpRedCharacterCustomEquipment.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomEquipment/CpRedCharacterCustomEquipment.java
@@ -28,19 +28,21 @@ public class CpRedCharacterCustomEquipment {
     private Long id;
     @ManyToOne
     @JoinColumn(
-            name = "equipment_id",
+            name = "customItem_id",
             referencedColumnName = "id",
             nullable = false
     )
-    private CpRedCustomEquipments equipmentId;
+    private CpRedCustomEquipments customItem;
     @ManyToOne
     @JoinColumn(
             name = "character_id",
             referencedColumnName = "id",
             nullable = false
     )
-    private CpRedCharacters characterId;
+    private CpRedCharacters character;
+    private Integer quantity;
     @Enumerated(EnumType.STRING)
     private CpRedCharacterItemStatus status;
+    @Column(length = 1000)
     private String description;
 }

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomEquipment/CpRedCharacterCustomEquipmentController.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomEquipment/CpRedCharacterCustomEquipmentController.java
@@ -1,0 +1,41 @@
+package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterCustomEquipment;
+
+import lombok.AllArgsConstructor;
+
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping(path = "api/v1/authorized")
+@AllArgsConstructor
+public class CpRedCharacterCustomEquipmentController {
+    private final CpRedCharacterCustomEquipmentService cpRedCharacterCustomEquipmentService;
+
+    // ============ User methods ============
+    @GetMapping(path = "/games/cpRed/characters/customEquipments/{characterId}")
+    public Map<String, Object> getCharacterCustomEquipment(@PathVariable("characterId") Long characterId) {
+        return cpRedCharacterCustomEquipmentService.getCharacterCustomEquipment(characterId);
+    }
+
+    @PostMapping(path = "/games/cpRed/characters/customEquipments/create")
+    public Map<String, Object> createCharacterCustomEquipment(@RequestBody AddCharacterCustomEquipmentRequest addCharacterCustomEquipmentRequest) {
+        return cpRedCharacterCustomEquipmentService.createCharacterCustomEquipment(addCharacterCustomEquipmentRequest);
+    }
+
+    @PutMapping(path = "/games/cpRed/characters/customEquipments/update/{characterCustomEquipmentId}")
+    public Map<String, Object> updateCharacterCustomEquipment(@PathVariable("characterCustomEquipmentId") Long characterCustomEquipmentId,
+                                                        @RequestBody UpdateCharacterCustomEquipmentRequest updateCharacterCustomEquipmentRequest) {
+        return cpRedCharacterCustomEquipmentService.updateCharacterCustomEquipment(characterCustomEquipmentId, updateCharacterCustomEquipmentRequest);
+    }
+
+    @DeleteMapping(path = "/games/cpRed/characters/customEquipments/delete/{characterCustomEquipmentId}")
+    public Map<String, Object> deleteCharacterCustomEquipment(@PathVariable("characterCustomEquipmentId") Long characterCustomEquipmentId) {
+        return cpRedCharacterCustomEquipmentService.deleteCharacterCustomEquipment(characterCustomEquipmentId);
+    }
+    // ============ Admin methods ============
+    @GetMapping(path = "/admin/games/cpRed/characters/customEquipments/all")
+    public Map<String, Object> getAllCharacterCustomEquipments() {
+        return cpRedCharacterCustomEquipmentService.getAllCharacterCustomEquipments();
+    }
+}

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomEquipment/CpRedCharacterCustomEquipmentDTO.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomEquipment/CpRedCharacterCustomEquipmentDTO.java
@@ -8,8 +8,10 @@ import lombok.ToString;
 @ToString
 @AllArgsConstructor
 public class CpRedCharacterCustomEquipmentDTO {
-    private Long equipmentId;
+    private Long id;
     private Long characterId;
+    private Long customItemId;
+    private Integer quantity;
     private String status;
     private String description;
 }

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomEquipment/CpRedCharacterCustomEquipmentRepository.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomEquipment/CpRedCharacterCustomEquipmentRepository.java
@@ -1,8 +1,16 @@
 package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterCustomEquipment;
 
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharacters;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.custom.customEquipments.CpRedCustomEquipments;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Arrays;
+import java.util.List;
+
 @Repository
 public interface CpRedCharacterCustomEquipmentRepository extends JpaRepository<CpRedCharacterCustomEquipment, Long> {
+    List<CpRedCharacterCustomEquipment> findAllByCharacter(CpRedCharacters character);
+
+    boolean existsByCharacterAndCustomItem(CpRedCharacters character, CpRedCustomEquipments customItem);
 }

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomEquipment/CpRedCharacterCustomEquipmentService.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomEquipment/CpRedCharacterCustomEquipmentService.java
@@ -1,0 +1,250 @@
+package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterCustomEquipment;
+
+import dev.goral.rpghandyhelper.game.Game;
+import dev.goral.rpghandyhelper.game.GameRepository;
+import dev.goral.rpghandyhelper.game.GameStatus;
+import dev.goral.rpghandyhelper.game.gameUsers.GameUsers;
+import dev.goral.rpghandyhelper.game.gameUsers.GameUsersRepository;
+import dev.goral.rpghandyhelper.game.gameUsers.GameUsersRole;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharacters;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharactersRepository;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.CpRedCharactersType;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.custom.customEquipments.CpRedCustomEquipments;
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.custom.customEquipments.CpRedCustomEquipmentsRepository;
+import dev.goral.rpghandyhelper.security.CustomReturnables;
+import dev.goral.rpghandyhelper.security.exceptions.ResourceNotFoundException;
+import dev.goral.rpghandyhelper.user.User;
+import dev.goral.rpghandyhelper.user.UserRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@Service
+@AllArgsConstructor
+public class CpRedCharacterCustomEquipmentService {
+    private final CpRedCharacterCustomEquipmentRepository cpRedCharacterCustomEquipmentRepository;
+    private final UserRepository userRepository;
+    private final CpRedCharactersRepository cpRedCharactersRepository;
+    private final GameRepository gameRepository;
+    private final GameUsersRepository gameUsersRepository;
+    private final CpRedCustomEquipmentsRepository cpRedCustomEquipmentsRepository;
+
+    public Map<String, Object> getCharacterCustomEquipment(Long characterId) {
+        CpRedCharacters character = cpRedCharactersRepository.findById(characterId)
+                .orElseThrow(() -> new ResourceNotFoundException("Postać o podanym ID nie została znaleziona."));
+        List<CpRedCharacterCustomEquipmentDTO> characterCustomEquipments = cpRedCharacterCustomEquipmentRepository.findAllByCharacter(character)
+                .stream()
+                .map(equipment -> new CpRedCharacterCustomEquipmentDTO(
+                        equipment.getId(),
+                        equipment.getCharacter().getId(),
+                        equipment.getCustomItem().getId(),
+                        equipment.getQuantity(),
+                        equipment.getStatus().toString(),
+                        equipment.getDescription()))
+                .toList();
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Customowe wyposażenie postaci pobrane pomyślnie");
+        response.put("characterCustomEquipments", characterCustomEquipments);
+        return response;
+
+    }
+
+    public Map<String, Object> createCharacterCustomEquipment(AddCharacterCustomEquipmentRequest addCharacterCustomEquipmentRequest) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
+
+        // Czy podano wszystkie wymagane pola w request
+        if (addCharacterCustomEquipmentRequest.getCharacterId() == null ||
+                addCharacterCustomEquipmentRequest.getCustomItemId() == null ||
+                addCharacterCustomEquipmentRequest.getQuantity() == null ||
+                addCharacterCustomEquipmentRequest.getStatus() == null) {
+            throw new IllegalArgumentException("Wszystkie pola muszą być wypełnione.");
+        }
+
+        // Czy istnieje character o podanym ID
+        CpRedCharacters character = cpRedCharactersRepository.findById(addCharacterCustomEquipmentRequest.getCharacterId())
+                .orElseThrow(() -> new ResourceNotFoundException("Postać o podanym ID nie została znaleziona."));
+
+        // Czy istnieje item o podanym ID
+        CpRedCustomEquipments customItem = cpRedCustomEquipmentsRepository.findById(addCharacterCustomEquipmentRequest.getCustomItemId())
+                .orElseThrow(() -> new ResourceNotFoundException("Customowy przedmiot o podanym ID nie został znaleziony."));
+
+        Game game = gameRepository.findById(character.getGame().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Gra powiązana z postacią nie została znaleziona."));
+
+        // Czy użytkownik należy do gry, do której należy postać
+        GameUsers gameUsers = gameUsersRepository.findGameUsersByUserIdAndGameId(currentUser.getId(), game.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Nie należysz do gry powiązanej z podaną postacią."));
+
+        // Czy postać należy do tej samej gry co przedmiot
+        if (!Objects.equals(character.getGame().getId(), customItem.getGameId().getId())) {
+            throw new ResourceNotFoundException("Postać nie należy do gry powiązanej z podanym customowym przedmiotem.");
+        }
+
+        // Czy ktoś chce zmieniać swoją postać lub jest GM-em w tej grze
+        if (gameUsers.getRole() != GameUsersRole.GAMEMASTER){
+            if (character.getType() != CpRedCharactersType.NPC) {
+                if (!Objects.equals(currentUser.getId(), character.getUser().getId())) {
+                    throw new ResourceNotFoundException("Zalogowany użytkownik nie jest GM-em w tej grze ani nie jest właścicielem postaci.");
+                }
+            } else {
+                throw new ResourceNotFoundException("Tylko GM może dodawać customowe wyposażenie postaci NPC.");
+            }
+        }
+        // Czy gra jest aktywna
+        if (game.getStatus() != GameStatus.ACTIVE) {
+            throw new IllegalStateException("Gra do której należy postać nie jest aktywna.");
+        }
+
+        // Sprawdzenie, czy postać ma już to wyposażenie
+        if (cpRedCharacterCustomEquipmentRepository.existsByCharacterAndCustomItem(character, customItem)) {
+            throw new IllegalArgumentException("Postać ma już to customowe wyposażenie.");
+        }
+
+        if (addCharacterCustomEquipmentRequest.getQuantity() < 0) {
+            throw new IllegalArgumentException("Ilość customowego wyposażenia musi być większa niż 0.");
+        }
+
+        // Tworzenie nowego wyposażenia postaci
+        CpRedCharacterCustomEquipment newCharacterCustomEquipment = new CpRedCharacterCustomEquipment(
+                null,
+                customItem,
+                character,
+                addCharacterCustomEquipmentRequest.getQuantity(),
+                addCharacterCustomEquipmentRequest.getStatus(),
+                customItem.getDescription()
+        );
+
+        cpRedCharacterCustomEquipmentRepository.save(newCharacterCustomEquipment);
+
+        return CustomReturnables.getOkResponseMap("Customowe wyposażenie zostało dodane do postaci");
+    }
+
+    public Map<String, Object> updateCharacterCustomEquipment(Long characterCustomEquipmentId,
+                                                              UpdateCharacterCustomEquipmentRequest updateCharacterCustomEquipmentRequest) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
+
+        // Czy istnieje wyposażenie postaci o podanym ID
+        CpRedCharacterCustomEquipment characterCustomEquipmentToUpdate = cpRedCharacterCustomEquipmentRepository.findById(characterCustomEquipmentId)
+                .orElseThrow(() -> new ResourceNotFoundException("Customowe wyposażenie postaci o podanym ID nie zostało znalezione."));
+
+        // Czy istnieje character o podanym ID
+        CpRedCharacters character = cpRedCharactersRepository.findById(characterCustomEquipmentToUpdate.getCharacter().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Postać o podanym ID nie została znaleziona."));
+
+        // Czy istnieje item o podanym ID
+        CpRedCustomEquipments customItem = cpRedCustomEquipmentsRepository.findById(characterCustomEquipmentToUpdate.getCustomItem().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Customowy przedmiot o podanym ID nie został znaleziony."));
+
+        Game game = gameRepository.findById(character.getGame().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Gra powiązana z postacią nie została znaleziona."));
+
+        // Czy użytkownik należy do gry, do której należy postać
+        GameUsers gameUsers = gameUsersRepository.findGameUsersByUserIdAndGameId(currentUser.getId(), game.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Nie należysz do gry powiązanej z podaną postacią."));
+
+        // Czy ktoś chce zmieniać swoją postać lub jest GM-em w tej grze
+        if (gameUsers.getRole() != GameUsersRole.GAMEMASTER){
+            if (character.getType() != CpRedCharactersType.NPC) {
+                if (!Objects.equals(currentUser.getId(), character.getUser().getId())) {
+                    throw new ResourceNotFoundException("Zalogowany użytkownik nie jest GM-em w tej grze ani nie jest właścicielem postaci.");
+                }
+            } else {
+                throw new ResourceNotFoundException("Tylko GM może modyfikować customowe wyposażenie postaci NPC.");
+            }
+        }
+        // Czy gra jest aktywna
+        if (game.getStatus() != GameStatus.ACTIVE) {
+            throw new IllegalStateException("Gra do której należy postać nie jest aktywna.");
+        }
+
+        // Sprawdzenie ilości przedmiotów
+        if (updateCharacterCustomEquipmentRequest.getQuantity() != null) {
+            if (updateCharacterCustomEquipmentRequest.getQuantity() < 0) {
+                throw new IllegalArgumentException("Ilość customowego wyposażenia musi być większa lub równa 0.");
+            }
+            characterCustomEquipmentToUpdate.setQuantity(updateCharacterCustomEquipmentRequest.getQuantity());
+        }
+
+        // Sprawdzenie statusu przedmiotów
+        if (updateCharacterCustomEquipmentRequest.getStatus() != null) {
+            characterCustomEquipmentToUpdate.setStatus(updateCharacterCustomEquipmentRequest.getStatus());
+        }
+
+        // Sprawdzenie opisu przedmiotów
+        if (updateCharacterCustomEquipmentRequest.getDescription() != null) {
+            if (updateCharacterCustomEquipmentRequest.getDescription().length() > 1000) {
+                throw new IllegalArgumentException("Opis nie może być dłuższy niż 1000 znaków.");
+            }
+            characterCustomEquipmentToUpdate.setDescription(updateCharacterCustomEquipmentRequest.getDescription());
+        }
+
+        // Zapisanie zmodyfikowanego wyposażenia postaci
+        cpRedCharacterCustomEquipmentRepository.save(characterCustomEquipmentToUpdate);
+
+        return CustomReturnables.getOkResponseMap("Customowe wyposażenie postaci zostało pomyślnie zmodyfikowane");
+    }
+
+    public Map<String, Object> deleteCharacterCustomEquipment(Long characterCustomEquipmentId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        User currentUser = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new ResourceNotFoundException("Zalogowany użytkownik nie został znaleziony."));
+
+        // Czy istnieje wyposażenie postaci o podanym ID
+        CpRedCharacterCustomEquipment characterCustomEquipmentToDelete = cpRedCharacterCustomEquipmentRepository.findById(characterCustomEquipmentId)
+                .orElseThrow(() -> new ResourceNotFoundException("Customowe wyposażenie postaci o podanym ID nie zostało znalezione."));
+
+        // Czy istnieje character o podanym ID
+        CpRedCharacters character = cpRedCharactersRepository.findById(characterCustomEquipmentToDelete.getCharacter().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Postać o podanym ID nie została znaleziona."));
+
+        // Czy istnieje item o podanym ID
+        CpRedCustomEquipments customItem = cpRedCustomEquipmentsRepository.findById(characterCustomEquipmentToDelete.getCustomItem().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Customowy przedmiot o podanym ID nie został znaleziony."));
+
+        Game game = gameRepository.findById(character.getGame().getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Gra powiązana z postacią nie została znaleziona."));
+
+        // Czy użytkownik należy do gry, do której należy postać
+        GameUsers gameUsers = gameUsersRepository.findGameUsersByUserIdAndGameId(currentUser.getId(), game.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Nie należysz do gry powiązanej z podaną postacią."));
+
+        // Czy ktoś chce zmieniać swoją postać lub jest GM-em w tej grze
+        if (gameUsers.getRole() != GameUsersRole.GAMEMASTER){
+            if (character.getType() != CpRedCharactersType.NPC) {
+                if (!Objects.equals(currentUser.getId(), character.getUser().getId())) {
+                    throw new ResourceNotFoundException("Zalogowany użytkownik nie jest GM-em w tej grze ani nie jest właścicielem postaci.");
+                }
+            } else {
+                throw new ResourceNotFoundException("Tylko GM może modyfikować customowe wyposażenie postaci NPC.");
+            }
+        }
+        // Czy gra jest aktywna
+        if (game.getStatus() != GameStatus.ACTIVE) {
+            throw new IllegalStateException("Gra do której należy postać nie jest aktywna.");
+        }
+
+        // Usunięcie wyposażenia postaci
+        cpRedCharacterCustomEquipmentRepository.delete(characterCustomEquipmentToDelete);
+
+        return CustomReturnables.getOkResponseMap("Customowe wyposażenie postaci zostało pomyślnie usunięte");
+    }
+
+    public Map<String, Object> getAllCharacterCustomEquipments() {
+        List<CpRedCharacterCustomEquipment> allCharacterCustomEquipments = cpRedCharacterCustomEquipmentRepository.findAll();
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Wszystkie customowe wyposażenia wszystkich postaci pobrane pomyślnie");
+        response.put("characterCustomEquipments", allCharacterCustomEquipments);
+        return response;
+    }
+}

--- a/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomEquipment/UpdateCharacterCustomEquipmentRequest.java
+++ b/src/main/java/dev/goral/rpghandyhelper/rpgSystems/cpRed/characters/characterCustomEquipment/UpdateCharacterCustomEquipmentRequest.java
@@ -1,0 +1,19 @@
+package dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterCustomEquipment;
+
+import dev.goral.rpghandyhelper.rpgSystems.cpRed.characters.characterItem.CpRedCharacterItemStatus;
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateCharacterCustomEquipmentRequest {
+    private Integer quantity;
+    private CpRedCharacterItemStatus status;
+    @Column(length = 1000)
+    private String description;
+}


### PR DESCRIPTION
# Info dla testerów
## Kontekst
Encja łącząca postać z customowymi itemami z wyposażenia (customowe wyposażenie to taka zbiorówka jak coś nie jest customową bronią czy innym pancerzem to jest właśnie tym). Nie ma tu nic specjalnego, jako że jest opcja ilości przedmiotów to nie da się mieć dwóch takich samych powiązań. Encja niemal identyczna do encji z PR#321. Jedyna różnica to dodatkowa walidacja czy postać i przedmiot pochodzą z tej samej gry.

Każdy obiekt zawiera 6 pól:
- `id` - identyfikator połączenia
- `customItem` - posiadany customowy przedmiot
- `character` - posiadająca przedmiot postać
- `quantity` - ilość przedmiotów
- `status` - czy amunicja jest przy postaci czy w schowku
- `description` - opis, domyślnie kopiowany z CpRedCustomEquipments ale możliwy do modyfikacji

Uprawnieniowo standardowo: Dodać/ modyfikować/usunąć customowy przedmiot postaci może tylko GM gry do której przypisana jest postać lub właściciel postaci.

## Endpointy
Do przetestowania 5 endpointów:

- `http://localhost:8888/api/v1/authorized/games/cpRed/characters/customEquipments/create` - dawanie customowego przedmiotu, podaje się tylko id postaci, id przedmiotu z podręcznika, ilość i status, a reszta kopiowana z templatki.
- `http://localhost:8888/api/v1/authorized/games/cpRed/characters/customEquipments/*` - zwraca listę customowego wyposażenia podanej po id postaci
- `http://localhost:8888/api/v1/authorized/admin/games/cpRed/characters/customEquipments/all` - zwraca listę wszystkich powiązań postaci z customowymi przedmiotami wyposażenia dla Admina
- `http://localhost:8888/api/v1/authorized/games/cpRed/characters/customEquipments/update/*` - pozwala modyfikować status, ilość i opis
- `http://localhost:8888/api/v1/authorized/games/cpRed/characters/customEquipments/delete/*` - pozwala usunąć dany customowy przedmiot

## Na koniec
Standardowo na branchu są zapytania w Jetclienice zrobione, konfig ten sam co do PRki #321.

Miłego testowania ;)
@Kosiorny @szxxlc 