### PR TITLE
Zmiana miejsca przechowywania zdjęć od użytkowników

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -77,6 +77,7 @@ jobs:
         echo "spring.security.oauth2.client.provider.discord.user-info-uri=https://discord.com/api/users/@me" >> src/main/resources/application.properties
         echo "spring.security.oauth2.client.provider.discord.user-name-attribute=id" >> src/main/resources/application.properties
         echo "baseUrl=http://localhost:8080" >> src/main/resources/application.properties
+        echo "userUploads=/opt/rpghh/uploads" >> src/main/resources/application.properties
         echo "server.port=8080" >> src/main/resources/application.properties
         echo "recaptcha.secret-key= ${{ secrets.RECAPTCHA_SECRET }}" >> src/main/resources/application.properties
         echo "jwt.secret=${{ secrets.JWT_SECRET }}" >> src/main/resources/application.properties

--- a/src/main/java/dev/goral/rpghandyhelper/security/WebSecurityConfig.java
+++ b/src/main/java/dev/goral/rpghandyhelper/security/WebSecurityConfig.java
@@ -3,7 +3,8 @@ package dev.goral.rpghandyhelper.security;
 import dev.goral.rpghandyhelper.config.jwt.JwtAuthenticationFilter;
 import dev.goral.rpghandyhelper.config.jwt.JwtTokenProvider;
 import dev.goral.rpghandyhelper.user.UserService;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -24,14 +25,16 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Configuration
-@AllArgsConstructor
+@RequiredArgsConstructor
 @EnableWebSecurity
-public class WebSecurityConfig {
+public class WebSecurityConfig implements WebMvcConfigurer {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserService userService;
@@ -39,9 +42,18 @@ public class WebSecurityConfig {
     private final AuthenticationSuccessHandler customAuthenticationSuccessHandler;
     private final CustomOAuth2UserService customOAuth2UserService;
 
+    @Value("${userUploads}")
+    private String userUploads;
+
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
         return config.getAuthenticationManager();
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:" + userUploads + "/");
     }
 
     @Bean

--- a/src/main/java/dev/goral/rpghandyhelper/user/UserController.java
+++ b/src/main/java/dev/goral/rpghandyhelper/user/UserController.java
@@ -1,7 +1,7 @@
 package dev.goral.rpghandyhelper.user;
 
 import dev.goral.rpghandyhelper.user.additional.PasswordRequest;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.util.Map;
 
 @RestController
-@AllArgsConstructor
+@RequiredArgsConstructor
 @RequestMapping("/api/v1/authorized")
 public class UserController {
     private final UserService userService;
@@ -47,7 +47,7 @@ public class UserController {
     }
 
     @GetMapping("/user/photo/username/{username}")
-    public Map<String, Object> getUserPhotoByUsername(@PathVariable String username) throws IOException {
+    public Map<String, Object> getUserPhotoByUsername(@PathVariable String username) {
         return userService.getUserPhotoByUsername(username);
     }
   

--- a/src/main/java/dev/goral/rpghandyhelper/user/UserController.java
+++ b/src/main/java/dev/goral/rpghandyhelper/user/UserController.java
@@ -46,6 +46,11 @@ public class UserController {
         return userService.getUserPhoto(filename);
     }
 
+    @GetMapping("/user/photo")
+    public Map<String, Object> getUserActualPhotoPath() {
+        return userService.getUserActualPhotoPath();
+    }
+
     @GetMapping("/user/photo/username/{username}")
     public Map<String, Object> getUserPhotoByUsername(@PathVariable String username) {
         return userService.getUserPhotoByUsername(username);

--- a/src/main/java/dev/goral/rpghandyhelper/user/UserService.java
+++ b/src/main/java/dev/goral/rpghandyhelper/user/UserService.java
@@ -355,4 +355,17 @@ public class UserService implements UserDetailsService {
         response.put("userPhotoPath", userPhotoPath);
         return response;
     }
+
+    public Map<String, Object> getUserActualPhotoPath() {
+        User user = (User) getAuthentication().getPrincipal();
+        String userPhotoPath = user.getUserPhotoPath();
+
+        if (userPhotoPath == null || userPhotoPath.isEmpty()) {
+            throw new ResourceNotFoundException("Użytkownik nie ma ustawionego zdjęcia profilowego.");
+        }
+
+        Map<String, Object> response = CustomReturnables.getOkResponseMap("Pobrano aktualną ścieżkę zdjęciową użytkownika.");
+        response.put("userPhotoPath", userPhotoPath);
+        return response;
+    }
 }

--- a/src/main/resources/templates/home/profile.html
+++ b/src/main/resources/templates/home/profile.html
@@ -393,12 +393,13 @@
                         const formData = new FormData();
                         formData.append("file", file);
 
-                        const uploadResponse = await fetch("/api/v1/authorized/user/photo", {
+                        const uploadResponse = await fetch("/api/v1/authorized/user/setUserPhotoPath", {
                             method: "POST",
                             headers: {
+                                "Content-Type": "application/json",
                                 "X-XSRF-TOKEN": getCookie("XSRF-TOKEN")
                             },
-                            body: formData
+                            body: path
                         });
 
                         const result = await uploadResponse.json();


### PR DESCRIPTION
Cześć,
naprawiłem jedną rzecz, która powinna zostać wykonana na samym starcie projektu. Od teraz pliki dodawane przez użytkowników nie będą już trzymane w folderach naszego projektu, tylko specjalnie wyznaczonym do tego miejsca na dysku.

## Co trzeba wykonać przed testowaniem zmian?

1. Dodać tę linijkę do `application.properties`:
```userUploads=C:\\rpghh```, gdzie ścieżka może być dowolna dodana przez was.

## Co konkretnie wytestować?
Trzeba pobawić się różnymi kombinacjami zmian zdjęć profilowych, dodaniem nowego, wyborem z dostępnych, dodaniem nowego i znów wyborem już dostępnego, dostarczonego przez nas, itp. itd. Chodzi o to, że gdy zmienia się zdjęcie profilowe użytkownika, to mamy mieć pewność, że jeśli to nie było zdjęcie defaultowe - to:
- stare zdjęcie ma być usunięte
- nowe pojawić się w folderze wskazanym przez was w `application.properties`
- zdjęcia defaultowe mają być nietykalne